### PR TITLE
Record evaluated hybrid retrieval baseline

### DIFF
--- a/docs/demo-roadmap.md
+++ b/docs/demo-roadmap.md
@@ -592,7 +592,7 @@ Verification:
 - Evaluation tunes fusion weights and query routing while the pgvector-backed
   semantic capability remains available.
 
-Implementation evidence (active sprint):
+Implementation evidence (completed 2026-08-08):
 
 - Migration `004_pgvector_retrieval.sql` enables pgvector and stores
   workspace-scoped 1,536-dimensional vectors with provider, model, dimension,
@@ -620,13 +620,21 @@ Implementation evidence (active sprint):
 - The reproducible PostgreSQL lexical baseline records recall@5 `1.0`, mean
   reciprocal rank `0.977273`, and citation coverage `1.0`; answer support
   remains explicitly unmeasured until a grounded agent run supplies answers.
-
-Remaining exit-gate evidence:
-
-- Run the checked-in cases with the selected deployed embedding model and
-  capture semantic and hybrid reports alongside the lexical baseline.
-- Use those measured reports to confirm or tune fusion and routing before
-  claiming retrieval-quality improvement.
+- Provider-backed captures with 1,536-dimensional
+  `openai/text-embedding-3-small` embeddings through OpenRouter are checked in
+  beside the lexical baseline. Semantic retrieval measured recall@5
+  `0.954545`, mean reciprocal rank `0.901515`, and citation coverage `1.0`.
+  Hybrid retrieval measured recall@5 `1.0`, mean reciprocal rank `0.969697`,
+  and citation coverage `1.0`.
+- Semantic-only retrieval missed one expected policy record in the top five;
+  deterministic hybrid fusion restored it at rank three. Hybrid therefore
+  leads for the future grounded agent when embeddings are healthy, lexical
+  remains the low-latency default and failure fallback, and semantic-only mode
+  remains available for diagnostics.
+- Hybrid matched lexical recall with a slightly lower reciprocal-rank score,
+  so the current claim is measured semantic capability and hybrid recall—not
+  a blanket quality improvement over lexical search. Answer support remains a
+  Phase 9 measurement because these captures did not generate answers.
 
 Exit gate:
 

--- a/docs/langchain.rag.workflow.md
+++ b/docs/langchain.rag.workflow.md
@@ -120,12 +120,28 @@ and citation candidates only. Answer fields must come from an actual grounded
 agent run, so a raw retrieval capture correctly receives no answer-support
 credit.
 
-The checked-in lexical baseline, captured against PostgreSQL 16 and pgvector
-0.8.6, achieved recall@5 of `1.0`, mean reciprocal rank of `0.977273`, and
-citation coverage of `1.0` on this synthetic corpus. Its answer-support score
-is deliberately `0.0` because no generated answers were part of that run. The
-report is stored at `evaluation/reports/lexical-baseline.json`; its local
-latency is a reference measurement, not a production service-level objective.
+The checked-in comparison now records all three modes on the same 25 cases and
+seven-record synthetic corpus:
+
+| Mode | Recall@5 | Mean reciprocal rank | Citation coverage | Mean retrieval latency | Estimated provider cost |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Lexical | `1.0` | `0.977273` | `1.0` | `18.167 ms` | `$0` |
+| Semantic | `0.954545` | `0.901515` | `1.0` | `2280.352 ms` | `$0.00001226` |
+| Hybrid | `1.0` | `0.969697` | `1.0` | `2260.406 ms` | `$0.00001226` |
+
+The lexical baseline ran in a disposable local PostgreSQL 16/pgvector 0.8.6
+container. The semantic and hybrid captures used an isolated temporary
+workspace in Neon PostgreSQL 18.4/pgvector 0.8.1 and
+`openai/text-embedding-3-small` through OpenRouter at 1,536 dimensions. Their
+latency therefore includes remote provider and database round trips and is a
+reference measurement, not a production service-level objective. Cost is an
+estimate based on 613 input tokens and the provider's listed input-token
+price.
+
+All answer-support scores are deliberately `0.0` because no generated answers
+were part of these retrieval-only runs. Reports are stored in
+`evaluation/reports/lexical-baseline.json`,
+`semantic-openrouter-baseline.json`, and `hybrid-openrouter-baseline.json`.
 
 The gate compares:
 
@@ -136,10 +152,21 @@ The gate compares:
 - unsupported-answer rate;
 - processing time and provider cost.
 
-The pgvector-backed semantic path is implemented regardless of the comparison
-result. Evaluation determines fusion weights, query routing, and when lexical,
-semantic, or hybrid ranking should lead. Product claims about improvement are
-made only when the measured results support them.
+The measured routing decision is deliberately conservative:
+
+- keep lexical retrieval as the low-latency, credential-free control-plane
+  default and provider-failure fallback;
+- use hybrid retrieval for the grounded agent when embeddings are healthy,
+  because it retained lexical recall@5 and recovered the expected result in
+  the one case missed by semantic-only retrieval;
+- keep semantic-only mode available for diagnostics and future comparison,
+  but do not route agent questions to it by default;
+- retain reciprocal-rank fusion with `k = 60` for the next vertical slice.
+
+Hybrid's mean reciprocal rank was slightly below lexical retrieval, so
+CarbonSage claims measured semantic capability and full hybrid recall on this
+corpus—not a blanket retrieval-quality improvement. Phase 9 must separately
+measure answer support once the grounded agent produces cited responses.
 
 ## Agent workflow
 

--- a/nzeroesg-api/evaluation/reports/hybrid-openrouter-baseline.json
+++ b/nzeroesg-api/evaluation/reports/hybrid-openrouter-baseline.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "captured_on": "2026-08-08",
+  "mode": "hybrid",
+  "cases": "../retrieval_cases.json",
+  "corpus": "../retrieval_corpus.json",
+  "database": "Neon PostgreSQL 18.4 with pgvector 0.8.1",
+  "environment": "isolated temporary workspace in the configured development database",
+  "embedding": {
+    "provider": "openrouter",
+    "model": "openai/text-embedding-3-small",
+    "dimensions": 1536,
+    "fusion": "reciprocal-rank fusion",
+    "fusion_k": 60,
+    "estimated_input_tokens": 613,
+    "estimated_provider_cost_usd": 0.00001226
+  },
+  "k": 5,
+  "indexing_latency_ms": 19795.041,
+  "metrics": {
+    "case_count": 25,
+    "recall_at_k": 1.0,
+    "mean_reciprocal_rank": 0.969697,
+    "citation_coverage": 1.0,
+    "answer_support_rate": 0.0,
+    "unsupported_answer_rate": 0.0,
+    "mean_latency_ms": 2260.406,
+    "provider_cost_usd": 0.00001226
+  },
+  "notes": [
+    "This is a retrieval-only baseline; no generated answers were evaluated.",
+    "The estimated cost uses 613 input tokens and the provider's listed $0.02 per million input-token price.",
+    "Latency includes remote embedding-provider and Neon round trips from a development machine and is not a production service-level objective.",
+    "Hybrid retrieval restored the expected Pacific Components record at rank three for the case missed by semantic-only retrieval.",
+    "Hybrid matched lexical recall at five with a slightly lower mean reciprocal rank; this report does not claim a quality improvement over lexical retrieval."
+  ]
+}

--- a/nzeroesg-api/evaluation/reports/semantic-openrouter-baseline.json
+++ b/nzeroesg-api/evaluation/reports/semantic-openrouter-baseline.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "captured_on": "2026-08-08",
+  "mode": "semantic",
+  "cases": "../retrieval_cases.json",
+  "corpus": "../retrieval_corpus.json",
+  "database": "Neon PostgreSQL 18.4 with pgvector 0.8.1",
+  "environment": "isolated temporary workspace in the configured development database",
+  "embedding": {
+    "provider": "openrouter",
+    "model": "openai/text-embedding-3-small",
+    "dimensions": 1536,
+    "estimated_input_tokens": 613,
+    "estimated_provider_cost_usd": 0.00001226
+  },
+  "k": 5,
+  "indexing_latency_ms": 22261.318,
+  "metrics": {
+    "case_count": 25,
+    "recall_at_k": 0.954545,
+    "mean_reciprocal_rank": 0.901515,
+    "citation_coverage": 1.0,
+    "answer_support_rate": 0.0,
+    "unsupported_answer_rate": 0.0,
+    "mean_latency_ms": 2280.352,
+    "provider_cost_usd": 0.00001226
+  },
+  "notes": [
+    "This is a retrieval-only baseline; no generated answers were evaluated.",
+    "The estimated cost uses 613 input tokens and the provider's listed $0.02 per million input-token price.",
+    "Latency includes remote embedding-provider and Neon round trips from a development machine and is not a production service-level objective.",
+    "Semantic-only retrieval omitted the expected Pacific Components record from the top five for the routine-air-freight policy case."
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,10 @@ evidence-grounded CarbonSage agent described in the roadmap.
 - Explicit lexical, pgvector semantic, and deterministic hybrid retrieval
   modes with workspace filtering, versioned embedding metadata, and a safe
   lexical fallback when no embedding provider is configured.
+- A checked-in 25-case retrieval evaluation: lexical and hybrid both reached
+  `1.0` recall@5, while hybrid recovered the one expected result missed by
+  semantic-only retrieval. The reports avoid claiming generated-answer
+  quality, which is evaluated in the next agent phase.
 - Scenario comparisons, accessible chart alternatives, printable report
   previews, and authenticated CSV export.
 - A Vercel client, Render API, Neon PostgreSQL database, and credential-free CI
@@ -75,17 +79,15 @@ evidence-grounded CarbonSage agent described in the roadmap.
 CarbonSage will build on that baseline in a controlled order:
 
 1. A small workspace artifact catalog with CRUD and provenance.
-2. Measured lexical, semantic, and hybrid retrieval comparisons using the
-   checked-in evaluation corpus to tune fusion and query routing.
-3. Typed, workspace-scoped tools for evidence search, emissions calculations,
+2. Typed, workspace-scoped tools for evidence search, emissions calculations,
    scenario comparison, and reports.
-4. A versioned response protocol for text, metrics, tables, charts, citations,
+3. A versioned response protocol for text, metrics, tables, charts, citations,
    warnings, artifact references, and confirmed actions.
-5. A dashboard agent playground using the same runtime and renderer as the
+4. A dashboard agent playground using the same runtime and renderer as the
    embedded experience.
-6. A framework-independent JavaScript loader and authenticated iframe.
-7. One explicit, read-only Google Drive selected-file import.
-8. Optionally, a read-only MCP adapter over the same stable application tools.
+5. A framework-independent JavaScript loader and authenticated iframe.
+6. One explicit, read-only Google Drive selected-file import.
+7. Optionally, a read-only MCP adapter over the same stable application tools.
 
 Dropbox, billing, organization administration, background synchronization,
 enterprise RBAC, and a family of framework-specific SDKs are intentionally


### PR DESCRIPTION
Records the provider-backed semantic and hybrid retrieval baselines, compares them with the lexical baseline, and documents the measured routing decision. Hybrid preserves recall at five and recovers the case missed by semantic-only retrieval; lexical remains the credential-free default and fallback. These are retrieval-only measurements and make no generated-answer quality claim.