### PR TITLE
Promote provider-aware production smoke

### DIFF
--- a/nzeroesg-client/e2e/demo.spec.ts
+++ b/nzeroesg-client/e2e/demo.spec.ts
@@ -56,12 +56,20 @@ test("completes the five-minute demo workflow and exports a report", async ({
 
   await page.getByLabel("Retrieval mode").selectOption("hybrid");
   await page.getByRole("button", { name: "Search citations" }).click();
-  await expect(
-    page.getByText(/Used lexical retrieval · semantic provider unavailable/),
-  ).toBeVisible();
-  await expect(
-    page.getByText(/hybrid search used the lexical baseline/),
-  ).toBeVisible();
+  const retrievalStatus = page.getByText(
+    /Used (hybrid|lexical) retrieval · semantic provider (available|unavailable)/,
+  );
+  await expect(retrievalStatus).toBeVisible();
+  const retrievalStatusText = await retrievalStatus.textContent();
+  if (retrievalStatusText?.includes("provider unavailable")) {
+    expect(retrievalStatusText).toContain(
+      "hybrid search used the lexical baseline",
+    );
+  } else {
+    expect(retrievalStatusText).toContain(
+      "Used hybrid retrieval · semantic provider available",
+    );
+  }
 
   await page.getByRole("button", { name: "Run scenario" }).click();
   await expect(page.getByText("Current baseline")).toBeVisible();


### PR DESCRIPTION
Promotes the browser assertion that verifies both valid retrieval configurations: semantic-enabled hybrid production and credential-free lexical fallback in local/CI. The suite passes 3/3 in both environments. Dev CI run 31298414492 passed all jobs.