### PR TITLE
Phase 7: add workspace artifact foundation

### DIFF
--- a/docs/app.architecture.md
+++ b/docs/app.architecture.md
@@ -125,6 +125,19 @@ Raw uploaded files remain temporary unless a measured requirement changes the
 retention policy. The artifact catalog retains provenance and normalized
 results, not an unbounded file store.
 
+The implemented lifecycle keeps creation behind the validated shipment,
+evidence, and report services rather than exposing an arbitrary file endpoint.
+Soft deletion removes an artifact from active catalog reads immediately.
+Shipment and evidence derivatives are then removed from active calculations,
+supplier cards, retrieval, embeddings, and citations; the workspace TTL is the
+outer cleanup boundary. A deleted report snapshot remains inaccessible and is
+removed when its workspace expires.
+
+The dashboard cookie resolves to a common `WorkspacePrincipal` containing the
+workspace, subject, audience, authentication method, scopes, and expiry. Quota
+state remains server-side. A future embed-token adapter must resolve to the
+same principal contract rather than adding a parallel authorization path.
+
 ## Source-of-truth boundaries
 
 Deterministic application code owns:

--- a/docs/demo-roadmap.md
+++ b/docs/demo-roadmap.md
@@ -589,6 +589,10 @@ Implementation evidence (completed locally 2026-08-09; promotion pending):
   report-snapshot actions. Local gates pass with 79 credential-free backend
   tests, 81 PostgreSQL/pgvector tests, the production frontend build, and four
   PostgreSQL-backed Playwright journeys.
+- Pull request `#10` passed GitHub Actions run
+  [`31325975412`](https://github.com/davidpal3c/NZeroESG_Scope3/actions/runs/31325975412),
+  including repository, backend, frontend, and PostgreSQL-backed browser jobs;
+  its Vercel preview deployment also completed successfully.
 
 Verification:
 

--- a/docs/demo-roadmap.md
+++ b/docs/demo-roadmap.md
@@ -41,13 +41,14 @@ The objective is complete when a new demo user can:
 8. Complete the workflow on the public deployment while automated smoke and
    end-to-end checks pass.
 
-## Current checkpoint — August 6, 2026
+## Current checkpoint — August 9, 2026
 
 The public demo finish line is now operational. Render serves the rebuilt
 FastAPI application with Neon PostgreSQL, the optional assistant is disabled,
 and Vercel serves the rebuilt client from `main`.
 
-The deployment correction is recorded in commits `3d14052` and `e20c476`:
+The deployment correction is recorded in commits `3d14052` and `e20c476`, and
+the CarbonSage infrastructure cleanup is recorded through commit `015abf0`:
 
 - Vercel's production build uses `next build --webpack` to produce the tracing
   artifact expected by the Vercel build hook.
@@ -57,6 +58,11 @@ The deployment correction is recorded in commits `3d14052` and `e20c476`:
   return `503` when the feature is disabled.
 - The public Playwright suite passes the five-minute workflow, report export,
   workspace isolation, keyboard entry, and narrow-viewport checks.
+- The existing Render API resource is renamed in place to `carbonsage-api`
+  while retaining its verified `nzeroesg-api.onrender.com` origin.
+- The standalone `nzeroesg-embedder` service is permanently deleted; semantic
+  retrieval runs through pgvector and the configured provider adapter in the
+  modular API.
 
 The next work should be hardening and measured product improvements, not a
 return to the abandoned GraphQL or embedder branches. ChromaDB, the standalone
@@ -109,23 +115,23 @@ The demo must still work when the optional LLM feature is disabled.
 
 ## Trusted baseline scope decisions
 
-| Candidate                    | Decision for the prototype                                                                                                                                                                                 |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/login` and authentication  | Build a clearly labelled demo-access flow using a server-issued, signed session and isolated expiring workspace. Do not build production identity management yet.                                          |
-| Functional portal            | Build one focused workspace dashboard: Overview, Shipments, Suppliers/Evidence, Scenarios, and Report.                                                                                                     |
-| CSV upload                   | Required. Support one documented schema, downloadable template, row validation, and a conservative row limit.                                                                                              |
-| File/document upload         | Required. Start with text-based PDF and optionally DOCX/TXT. Do not add OCR or scanned-document support.                                                                                                   |
-| Reports                      | Required. Build a printable HTML report and CSV export first; avoid a separate report service.                                                                                                             |
-| Charts/Recharts              | Include a small set of decision-useful charts: emissions by mode, top shipment hotspots, and scenario comparison.                                                                                          |
-| Supplier cards and metadata  | Required. Show source status, certifications, region, transport modes, evidence links, data freshness, and missing fields.                                                                                 |
-| Quick replies                | Include only after the core workflow works. Quick replies should trigger explicit product actions, not decorative prompts.                                                                                 |
-| Confidence/source/time       | Always show sources and processing time. Replace uncalibrated “confidence” with evidence completeness and data-quality status.                                                                             |
-| Memory isolation             | Required. Remove process-global user memory. Store only workspace-scoped conversation/context needed for the demo and expire it.                                                                           |
-| Calculation correctness      | First implementation milestone and a release blocker.                                                                                                                                                      |
-| Supplier/RAG                 | Use structured supplier records plus cited document retrieval. Keep PostgreSQL full-text search and implement pgvector semantic retrieval; evaluation tunes deterministic hybrid ranking and query routing.           |
-| Google Drive                 | Not part of the initial public finish line. It may be used to source test documents during development. A later read-only “import selected file” experiment is acceptable after local ingestion is stable. |
-| GraphQL/NestJS/microservices | Explicitly out of scope.                                                                                                                                                                                   |
-| Billing                      | Out of scope. Protect costs with quotas, rate limits, retention limits, and a demo access gate.                                                                                                            |
+| Candidate                    | Decision for the prototype                                                                                                                                                                                  |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/login` and authentication  | Build a clearly labelled demo-access flow using a server-issued, signed session and isolated expiring workspace. Do not build production identity management yet.                                           |
+| Functional portal            | Build one focused workspace dashboard: Overview, Shipments, Suppliers/Evidence, Scenarios, and Report.                                                                                                      |
+| CSV upload                   | Required. Support one documented schema, downloadable template, row validation, and a conservative row limit.                                                                                               |
+| File/document upload         | Required. Start with text-based PDF and optionally DOCX/TXT. Do not add OCR or scanned-document support.                                                                                                    |
+| Reports                      | Required. Build a printable HTML report and CSV export first; avoid a separate report service.                                                                                                              |
+| Charts/Recharts              | Include a small set of decision-useful charts: emissions by mode, top shipment hotspots, and scenario comparison.                                                                                           |
+| Supplier cards and metadata  | Required. Show source status, certifications, region, transport modes, evidence links, data freshness, and missing fields.                                                                                  |
+| Quick replies                | Include only after the core workflow works. Quick replies should trigger explicit product actions, not decorative prompts.                                                                                  |
+| Confidence/source/time       | Always show sources and processing time. Replace uncalibrated “confidence” with evidence completeness and data-quality status.                                                                              |
+| Memory isolation             | Required. Remove process-global user memory. Store only workspace-scoped conversation/context needed for the demo and expire it.                                                                            |
+| Calculation correctness      | First implementation milestone and a release blocker.                                                                                                                                                       |
+| Supplier/RAG                 | Use structured supplier records plus cited document retrieval. Keep PostgreSQL full-text search and implement pgvector semantic retrieval; evaluation tunes deterministic hybrid ranking and query routing. |
+| Google Drive                 | Not part of the initial public finish line. It may be used to source test documents during development. A later read-only “import selected file” experiment is acceptable after local ingestion is stable.  |
+| GraphQL/NestJS/microservices | Explicitly out of scope.                                                                                                                                                                                    |
+| Billing                      | Out of scope. Protect costs with quotas, rate limits, retention limits, and a demo access gate.                                                                                                             |
 
 ## Trusted baseline architecture
 
@@ -484,7 +490,7 @@ Verification:
 - [x] Scenario totals reconcile with the calculation engine.
 - [x] Charts and report values come from the same typed result payload.
 - [x] Exported data matches the displayed workspace state.
-- [ ] Keyboard and responsive checks pass for the primary workflow.
+- [x] Keyboard and responsive checks pass for the primary workflow.
 
 The remaining Phase 5 browser gate is now complete. The local and public
 Chromium suites cover the full interaction, including keyboard navigation,
@@ -555,6 +561,34 @@ Deliverables:
   artifacts without replacing their domain schemas with generic JSON.
 - Define a common internal workspace principal for the existing dashboard
   session and future embed credentials.
+
+Implementation evidence (completed locally 2026-08-09; promotion pending):
+
+- Migration `005_artifact_catalog.sql` adds workspace-owned shipment dataset,
+  evidence document, and report snapshot records with status, provenance,
+  content identity, version, authorship, timestamps, and soft-deletion state.
+- Existing normalized shipment rows and evidence documents carry mandatory
+  workspace/artifact foreign keys. Evidence search citations now preserve the
+  artifact id in addition to document, page, and chunk identity.
+- `GET /artifacts`, `GET /artifacts/{id}`, `PATCH /artifacts/{id}`, and
+  `DELETE /artifacts/{id}` provide bounded list, detail, rename, and
+  soft-delete operations. Cross-workspace requests receive the same `404` as
+  absent records.
+- Shipment and evidence uploads create provenance-bearing artifacts through
+  their existing validated domain pipelines. `POST /reports/snapshots` stores
+  a versioned typed report payload instead of genericizing shipment or
+  evidence domain records.
+- `WorkspacePrincipal` adapts the signed dashboard session into workspace,
+  subject, audience, method, scope, and expiry claims without moving mutable
+  quotas into the credential.
+- Deleting a shipment or evidence artifact immediately removes its normalized
+  data from active calculations, retrieval, citations, and supplier counts;
+  workspace expiry remains the outer retention boundary. Report snapshots are
+  hidden from both catalog and typed snapshot reads.
+- The dashboard exposes provenance inspection, rename, confirmed delete, and
+  report-snapshot actions. Local gates pass with 79 credential-free backend
+  tests, 81 PostgreSQL/pgvector tests, the production frontend build, and four
+  PostgreSQL-backed Playwright journeys.
 
 Verification:
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -53,6 +53,9 @@ docker compose up --build
 
 Compose uses the pinned `pgvector/pgvector:0.8.6-pg16-bookworm` image and
 applies the checked-in migrations for workspace, evidence, and vector records.
+Migration `005_artifact_catalog.sql` adds the workspace artifact catalog,
+source links, and typed report snapshots without adding object storage or a
+new service.
 Native development without `DATABASE_URL` uses the explicitly documented
 in-memory adapter; production must configure a managed PostgreSQL URL.
 
@@ -156,9 +159,11 @@ expiry.
 ## Deployment safety
 
 Historical Render deploy hooks were committed in an earlier workflow. On
-August 5, 2026, the user confirmed that the Render API key was rotated, the
-affected Render service no longer exists, and the historical hook references
-are disabled. No Render deployment workflow is currently tracked. If a future
+August 5, 2026, the user confirmed that the Render API key was rotated and the
+historical hook references were disabled. On August 9, the suspended legacy
+`nzeroesg-embedder` service was permanently deleted after explicit approval.
+The in-place `carbonsage-api` resource is now the only Render service for this
+project. No Render deployment workflow is currently tracked. If a future
 backend service is created, deployment configuration must use newly managed
 repository or provider-managed secrets and must not restore historical hook
 credentials.

--- a/docs/langchain.rag.workflow.md
+++ b/docs/langchain.rag.workflow.md
@@ -30,6 +30,12 @@ is grounded only when the system can show:
 
 Generated prose never becomes a supplier fact or calculation source.
 
+The implemented citation contract carries `artifact_id`, document SHA-256,
+filename, page when available, and chunk index. Artifact soft deletion removes
+the linked document and embeddings from active lexical, semantic, and hybrid
+retrieval, so a stale citation cannot resolve through another workspace or a
+deleted source.
+
 ## Ingestion and indexing
 
 ```mermaid
@@ -123,11 +129,11 @@ credit.
 The checked-in comparison now records all three modes on the same 25 cases and
 seven-record synthetic corpus:
 
-| Mode | Recall@5 | Mean reciprocal rank | Citation coverage | Mean retrieval latency | Estimated provider cost |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| Lexical | `1.0` | `0.977273` | `1.0` | `18.167 ms` | `$0` |
-| Semantic | `0.954545` | `0.901515` | `1.0` | `2280.352 ms` | `$0.00001226` |
-| Hybrid | `1.0` | `0.969697` | `1.0` | `2260.406 ms` | `$0.00001226` |
+| Mode     |   Recall@5 | Mean reciprocal rank | Citation coverage | Mean retrieval latency | Estimated provider cost |
+| -------- | ---------: | -------------------: | ----------------: | ---------------------: | ----------------------: |
+| Lexical  |      `1.0` |           `0.977273` |             `1.0` |            `18.167 ms` |                    `$0` |
+| Semantic | `0.954545` |           `0.901515` |             `1.0` |          `2280.352 ms` |           `$0.00001226` |
+| Hybrid   |      `1.0` |           `0.969697` |             `1.0` |          `2260.406 ms` |           `$0.00001226` |
 
 The lexical baseline ran in a disposable local PostgreSQL 16/pgvector 0.8.6
 container. The semantic and hybrid captures used an isolated temporary

--- a/nzeroesg-api/api/artifacts.py
+++ b/nzeroesg-api/api/artifacts.py
@@ -1,0 +1,129 @@
+"""Bounded workspace artifact catalog API."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+
+from api.workspaces import require_workspace_principal
+from config import database_url_for_runtime
+from domain.artifacts.models import Artifact, ArtifactKind, ArtifactSourceType, ArtifactStatus
+from domain.workspaces.principals import WorkspacePrincipal
+from persistence.artifacts import (
+    ArtifactNotFoundError,
+    build_artifact_repository,
+    build_report_snapshot_repository,
+)
+
+artifacts_router = APIRouter(prefix="/artifacts", tags=["artifacts"])
+artifact_repository = build_artifact_repository(database_url_for_runtime())
+report_snapshot_repository = build_report_snapshot_repository(database_url_for_runtime())
+
+
+class ArtifactResponse(BaseModel):
+    artifact_id: str
+    workspace_id: str
+    kind: ArtifactKind
+    title: str
+    status: ArtifactStatus
+    source_type: ArtifactSourceType
+    source_reference: str | None
+    media_type: str | None
+    content_sha256: str | None
+    version: int
+    metadata: dict[str, Any]
+    created_by: str
+    created_at: str
+    updated_at: str
+    deleted_at: str | None
+
+
+class ArtifactListResponse(BaseModel):
+    artifacts: list[ArtifactResponse]
+
+
+class ArtifactRenameRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=255)
+
+
+def artifact_response(artifact: Artifact) -> ArtifactResponse:
+    return ArtifactResponse.model_validate(artifact.to_dict())
+
+
+def _not_found() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Artifact was not found in this workspace.",
+    )
+
+
+@artifacts_router.get("", response_model=ArtifactListResponse)
+async def list_artifacts(
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
+) -> ArtifactListResponse:
+    return ArtifactListResponse(
+        artifacts=[
+            artifact_response(artifact)
+            for artifact in artifact_repository.list_for_workspace(principal.workspace_id)
+        ]
+    )
+
+
+@artifacts_router.get("/{artifact_id}", response_model=ArtifactResponse)
+async def get_artifact(
+    artifact_id: str,
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
+) -> ArtifactResponse:
+    artifact = artifact_repository.get(principal.workspace_id, artifact_id)
+    if artifact is None:
+        raise _not_found()
+    return artifact_response(artifact)
+
+
+@artifacts_router.patch("/{artifact_id}", response_model=ArtifactResponse)
+async def rename_artifact(
+    artifact_id: str,
+    payload: ArtifactRenameRequest,
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
+) -> ArtifactResponse:
+    try:
+        artifact = artifact_repository.rename(
+            principal.workspace_id,
+            artifact_id,
+            payload.title,
+        )
+    except (ArtifactNotFoundError, ValueError) as exc:
+        if isinstance(exc, ArtifactNotFoundError):
+            raise _not_found() from exc
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    return artifact_response(artifact)
+
+
+@artifacts_router.delete("/{artifact_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_artifact(
+    artifact_id: str,
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
+) -> Response:
+    artifact = artifact_repository.get(principal.workspace_id, artifact_id)
+    if artifact is None:
+        raise _not_found()
+
+    artifact_repository.soft_delete(principal.workspace_id, artifact_id)
+
+    # Imports are intentionally local: the API modules share repository instances,
+    # while persistence modules remain independent of FastAPI and each other.
+    if artifact.kind is ArtifactKind.SHIPMENT_DATASET:
+        from api.shipments import shipment_repository
+
+        shipment_repository.delete_for_artifact(principal.workspace_id, artifact_id)
+    elif artifact.kind is ArtifactKind.EVIDENCE_DOCUMENT:
+        from api.evidence import evidence_repository
+
+        evidence_repository.delete_for_artifact(principal.workspace_id, artifact_id)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/nzeroesg-api/api/emissions.py
+++ b/nzeroesg-api/api/emissions.py
@@ -5,14 +5,14 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from api.workspaces import require_workspace_session, workspace_repository
+from api.workspaces import require_workspace_principal, workspace_repository
 from domain.emissions.calculator import (
     CalculationResult,
     ComparisonResult,
     calculate_emissions,
     compare_emissions,
 )
-from domain.workspaces.sessions import WorkspaceSession
+from domain.workspaces.principals import WorkspacePrincipal
 from persistence.workspaces import QuotaExceededError, WorkspaceNotFoundError
 
 TransportMethod = Literal[
@@ -116,7 +116,7 @@ def _raise_calculation_error(exc: ValueError) -> HTTPException:
 @emissions_router.post("/calculate", response_model=CalculationResponse)
 async def calculate(
     payload: EmissionsRequest,
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
 ) -> CalculationResponse:
     try:
         result = calculate_emissions(
@@ -131,14 +131,14 @@ async def calculate(
         )
     except ValueError as exc:
         raise _raise_calculation_error(exc) from exc
-    _consume_analysis_run(workspace.workspace_id)
+    _consume_analysis_run(principal.workspace_id)
     return _calculation_response(result)
 
 
 @emissions_router.post("/compare", response_model=ComparisonResponse)
 async def compare(
     payload: ComparisonRequest,
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
 ) -> ComparisonResponse:
     try:
         result = compare_emissions(
@@ -153,7 +153,7 @@ async def compare(
         )
     except ValueError as exc:
         raise _raise_calculation_error(exc) from exc
-    _consume_analysis_run(workspace.workspace_id)
+    _consume_analysis_run(principal.workspace_id)
     return ComparisonResponse.model_validate(_comparison_payload(result))
 
 

--- a/nzeroesg-api/api/evidence.py
+++ b/nzeroesg-api/api/evidence.py
@@ -7,8 +7,10 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Upload
 from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 
-from api.workspaces import require_workspace_session, workspace_repository
+from api.artifacts import ArtifactResponse, artifact_repository, artifact_response
+from api.workspaces import require_workspace_principal, workspace_repository
 from config import database_url_for_runtime, settings
+from domain.artifacts.models import ArtifactKind, ArtifactSourceType, create_artifact
 from domain.evidence.embeddings import (
     EmbeddingProviderError,
     build_embedding_adapter,
@@ -27,7 +29,7 @@ from domain.evidence.models import (
     SupplierMetadata,
 )
 from domain.evidence.retrieval import RetrievalMode, reciprocal_rank_fusion
-from domain.workspaces.sessions import WorkspaceSession
+from domain.workspaces.principals import WorkspacePrincipal
 from persistence.evidence import build_evidence_repository
 from persistence.workspaces import QuotaExceededError, WorkspaceNotFoundError
 
@@ -54,6 +56,7 @@ class SupplierResponse(BaseModel):
 
 
 class CitationResponse(BaseModel):
+    artifact_id: str
     page_number: int | None
     chunk_index: int
     document_sha256: str
@@ -76,6 +79,7 @@ class EvidenceMatchResponse(BaseModel):
 
 
 class EvidenceUploadResponse(BaseModel):
+    artifact: ArtifactResponse
     supplier: SupplierResponse
     filename: str
     media_type: str
@@ -236,7 +240,7 @@ async def _search_with_mode(
 async def upload_evidence(
     file: Annotated[UploadFile, File(description="A UTF-8 TXT or text-based PDF")],
     supplier_name: Annotated[str, Form()],
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
     supplier_region: Annotated[str | None, Form()] = None,
     certifications: Annotated[str | None, Form()] = None,
     transport_modes: Annotated[str | None, Form()] = None,
@@ -265,14 +269,47 @@ async def upload_evidence(
         certifications=normalized_supplier[2],
         transport_modes=normalized_supplier[3],
     )
-    _consume_document_quota(workspace.workspace_id)
-    stored_supplier = evidence_repository.store(
-        workspace.workspace_id,
-        supplier,
-        extraction.document,
+    if evidence_repository.has_document(principal.workspace_id, extraction.document.sha256):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This evidence document already exists in the workspace.",
+        )
+    _consume_document_quota(principal.workspace_id)
+    artifact = create_artifact(
+        workspace_id=principal.workspace_id,
+        kind=ArtifactKind.EVIDENCE_DOCUMENT,
+        title=extraction.document.filename,
+        source_type=ArtifactSourceType.LOCAL_UPLOAD,
+        source_reference=extraction.document.filename,
+        media_type=extraction.document.media_type,
+        content_sha256=extraction.document.sha256,
+        created_by=principal.subject,
     )
-    embedding_status = await _index_document(workspace.workspace_id, extraction.document)
+    artifact_repository.create(artifact)
+    try:
+        stored_supplier = evidence_repository.store(
+            principal.workspace_id,
+            artifact.artifact_id,
+            supplier,
+            extraction.document,
+        )
+        embedding_status = await _index_document(principal.workspace_id, extraction.document)
+        artifact = artifact_repository.mark_ready(
+            principal.workspace_id,
+            artifact.artifact_id,
+            {
+                "supplier_id": stored_supplier.supplier_id,
+                "supplier_name": stored_supplier.name,
+                "page_count": extraction.document.page_count,
+                "chunk_count": len(extraction.document.chunks),
+                "embedding_status": embedding_status,
+            },
+        )
+    except Exception:
+        artifact_repository.mark_failed(principal.workspace_id, artifact.artifact_id)
+        raise
     return EvidenceUploadResponse(
+        artifact=artifact_response(artifact),
         supplier=_supplier_response(stored_supplier),
         filename=extraction.document.filename,
         media_type=extraction.document.media_type,
@@ -286,12 +323,12 @@ async def upload_evidence(
 
 @evidence_router.get("/suppliers", response_model=SupplierListResponse)
 async def list_suppliers(
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
 ) -> SupplierListResponse:
     return SupplierListResponse(
         suppliers=[
             _supplier_response(supplier)
-            for supplier in evidence_repository.list_suppliers(workspace.workspace_id)
+            for supplier in evidence_repository.list_suppliers(principal.workspace_id)
         ]
     )
 
@@ -299,7 +336,7 @@ async def list_suppliers(
 @evidence_router.get("/evidence/search", response_model=EvidenceSearchResponse)
 async def search_evidence(
     query: Annotated[str, Query(min_length=2, max_length=200)],
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
     mode: Annotated[RetrievalMode, Query()] = RetrievalMode.LEXICAL,
 ) -> EvidenceSearchResponse:
     normalized_query = query.strip()
@@ -309,7 +346,7 @@ async def search_evidence(
             detail="Evidence search query must contain at least two characters.",
         )
     mode_used, matches, warning, semantic_available = await _search_with_mode(
-        workspace_id=workspace.workspace_id,
+        workspace_id=principal.workspace_id,
         query=normalized_query,
         requested_mode=mode,
     )

--- a/nzeroesg-api/api/reports.py
+++ b/nzeroesg-api/api/reports.py
@@ -3,19 +3,34 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import io
+import json
 import time
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from api.artifacts import (
+    ArtifactResponse,
+    artifact_repository,
+    artifact_response,
+    report_snapshot_repository,
+)
 from api.evidence import evidence_repository
 from api.shipments import shipment_repository
-from api.workspaces import require_workspace_session
+from api.workspaces import require_workspace_principal
+from domain.artifacts.models import (
+    ArtifactKind,
+    ArtifactSourceType,
+    ReportSnapshot,
+    create_artifact,
+)
 from domain.scenarios.comparison import compare_shipment_modes
 from domain.shipments.analysis import analyze_shipments
-from domain.workspaces.sessions import WorkspaceSession
+from domain.workspaces.principals import WorkspacePrincipal
 
 reports_router = APIRouter(prefix="/reports", tags=["reports"])
 
@@ -27,6 +42,17 @@ class ReportResponse(BaseModel):
     scenario: dict[str, object] | None
     suppliers: list[dict[str, object]]
     methodology: dict[str, object]
+
+
+class ReportSnapshotRequest(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=255)
+    alternative_mode: str | None = Field(default=None, max_length=30)
+
+
+class ReportSnapshotResponse(BaseModel):
+    artifact: ArtifactResponse
+    schema_version: str
+    report: ReportResponse
 
 
 def _build_report(workspace_id: str, alternative_mode: str | None) -> ReportResponse:
@@ -64,10 +90,93 @@ def _build_report(workspace_id: str, alternative_mode: str | None) -> ReportResp
 
 @reports_router.get("/preview", response_model=ReportResponse)
 async def report_preview(
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
     alternative_mode: Annotated[str | None, Query(max_length=30)] = None,
 ) -> ReportResponse:
-    return _build_report(workspace.workspace_id, alternative_mode)
+    return _build_report(principal.workspace_id, alternative_mode)
+
+
+@reports_router.post(
+    "/snapshots",
+    response_model=ReportSnapshotResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_report_snapshot(
+    payload: ReportSnapshotRequest,
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
+) -> ReportSnapshotResponse:
+    report = _build_report(principal.workspace_id, payload.alternative_mode)
+    if report.shipment_analysis.get("shipment_count", 0) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="A report snapshot requires an active shipment dataset.",
+        )
+    serialized = report.model_dump(mode="json")
+    digest = hashlib.sha256(
+        json.dumps(serialized, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    title = (payload.title.strip() if payload.title else None) or datetime.fromtimestamp(
+        report.generated_at, UTC
+    ).strftime("Decision report · %Y-%m-%d %H:%M UTC")
+    artifact = create_artifact(
+        workspace_id=principal.workspace_id,
+        kind=ArtifactKind.REPORT_SNAPSHOT,
+        title=title,
+        source_type=ArtifactSourceType.GENERATED,
+        source_reference=(
+            f"alternative_mode={payload.alternative_mode}" if payload.alternative_mode else None
+        ),
+        media_type="application/vnd.carbonsage.report+json",
+        content_sha256=digest,
+        created_by=principal.subject,
+    )
+    artifact_repository.create(artifact)
+    try:
+        report_snapshot_repository.store(
+            ReportSnapshot(
+                artifact_id=artifact.artifact_id,
+                workspace_id=principal.workspace_id,
+                schema_version="1.0",
+                payload=serialized,
+                generated_at=datetime.fromtimestamp(report.generated_at, UTC),
+            )
+        )
+        artifact = artifact_repository.mark_ready(
+            principal.workspace_id,
+            artifact.artifact_id,
+            {
+                "shipment_count": report.shipment_analysis.get("shipment_count", 0),
+                "supplier_count": len(report.suppliers),
+                "alternative_mode": payload.alternative_mode,
+            },
+        )
+    except Exception:
+        artifact_repository.mark_failed(principal.workspace_id, artifact.artifact_id)
+        raise
+    return ReportSnapshotResponse(
+        artifact=artifact_response(artifact),
+        schema_version="1.0",
+        report=report,
+    )
+
+
+@reports_router.get("/snapshots/{artifact_id}", response_model=ReportSnapshotResponse)
+async def get_report_snapshot(
+    artifact_id: str,
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
+) -> ReportSnapshotResponse:
+    artifact = artifact_repository.get(principal.workspace_id, artifact_id)
+    snapshot = report_snapshot_repository.get(principal.workspace_id, artifact_id)
+    if artifact is None or artifact.kind is not ArtifactKind.REPORT_SNAPSHOT or snapshot is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Report snapshot was not found in this workspace.",
+        )
+    return ReportSnapshotResponse(
+        artifact=artifact_response(artifact),
+        schema_version=snapshot.schema_version,
+        report=ReportResponse.model_validate(snapshot.payload),
+    )
 
 
 def _safe_csv_cell(value: object) -> str:
@@ -79,10 +188,10 @@ def _safe_csv_cell(value: object) -> str:
 
 @reports_router.get("/export.csv")
 async def report_csv(
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
     alternative_mode: Annotated[str | None, Query(max_length=30)] = None,
 ) -> Response:
-    report = _build_report(workspace.workspace_id, alternative_mode)
+    report = _build_report(principal.workspace_id, alternative_mode)
     output = io.StringIO(newline="")
     writer = csv.writer(output)
     writer.writerow(("section", "field", "value"))

--- a/nzeroesg-api/api/scenarios.py
+++ b/nzeroesg-api/api/scenarios.py
@@ -6,9 +6,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from api.shipments import shipment_repository
-from api.workspaces import require_workspace_session, workspace_repository
+from api.workspaces import require_workspace_principal, workspace_repository
 from domain.scenarios.comparison import compare_shipment_modes
-from domain.workspaces.sessions import WorkspaceSession
+from domain.workspaces.principals import WorkspacePrincipal
 from persistence.workspaces import QuotaExceededError, WorkspaceNotFoundError
 
 ScenarioMode = Literal["plane", "air", "truck", "train", "ship", "ocean container"]
@@ -53,9 +53,9 @@ def _consume_analysis_run(workspace_id: str) -> None:
 @scenarios_router.post("/compare", response_model=ScenarioResponse)
 async def compare_scenario(
     payload: ScenarioRequest,
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
 ) -> ScenarioResponse:
-    shipments = shipment_repository.list_for_workspace(workspace.workspace_id)
+    shipments = shipment_repository.list_for_workspace(principal.workspace_id)
     try:
         comparison = compare_shipment_modes(
             shipments,
@@ -66,5 +66,5 @@ async def compare_scenario(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(exc),
         ) from exc
-    _consume_analysis_run(workspace.workspace_id)
+    _consume_analysis_run(principal.workspace_id)
     return ScenarioResponse.model_validate(comparison.to_dict())

--- a/nzeroesg-api/api/shipments.py
+++ b/nzeroesg-api/api/shipments.py
@@ -1,12 +1,15 @@
 """Typed HTTP boundary for bounded shipment CSV ingestion."""
 
+from hashlib import sha256
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel
 
-from api.workspaces import require_workspace_session, workspace_repository
+from api.artifacts import ArtifactResponse, artifact_repository, artifact_response
+from api.workspaces import require_workspace_principal, workspace_repository
 from config import database_url_for_runtime
+from domain.artifacts.models import Artifact, ArtifactKind, ArtifactSourceType, create_artifact
 from domain.shipments.analysis import ShipmentAnalysis, analyze_shipments
 from domain.shipments.ingestion import (
     ALLOWED_CONTENT_TYPES,
@@ -14,7 +17,7 @@ from domain.shipments.ingestion import (
     parse_shipments_csv,
 )
 from domain.shipments.models import NormalizedShipment
-from domain.workspaces.sessions import WorkspaceSession
+from domain.workspaces.principals import WorkspacePrincipal
 from persistence.shipments import build_shipment_repository
 from persistence.workspaces import QuotaExceededError, WorkspaceNotFoundError
 
@@ -67,6 +70,7 @@ class ShipmentAnalysisResponse(BaseModel):
 
 
 class ShipmentUploadResponse(BaseModel):
+    artifact: ArtifactResponse | None
     accepted_rows: int
     errors: list[ShipmentErrorResponse]
     warnings: list[str]
@@ -85,11 +89,13 @@ def _shipment_response(shipment: NormalizedShipment) -> ShipmentRowResponse:
 def _response(
     rows: tuple[NormalizedShipment, ...],
     *,
+    artifact: Artifact | None = None,
     errors: tuple[dict[str, object], ...] = (),
     warnings: tuple[str, ...] = (),
 ) -> ShipmentUploadResponse:
     analysis = analyze_shipments(rows, parser_warnings=warnings)
     return ShipmentUploadResponse(
+        artifact=artifact_response(artifact) if artifact else None,
         accepted_rows=len(rows),
         errors=[ShipmentErrorResponse.model_validate(error) for error in errors],
         warnings=list(analysis.warnings),
@@ -116,7 +122,7 @@ def _consume_analysis_run(workspace_id: str) -> None:
 @shipments_router.post("/upload", response_model=ShipmentUploadResponse)
 async def upload_shipments(
     file: Annotated[UploadFile, File(description="A UTF-8 shipment CSV")],
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
 ) -> ShipmentUploadResponse:
     media_type = (file.content_type or "").split(";", 1)[0].strip().lower()
     if media_type not in ALLOWED_CONTENT_TYPES:
@@ -129,17 +135,56 @@ async def upload_shipments(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail="File name must end with .csv.",
         )
+    if len(file.filename) > 255:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="File name must contain at most 255 characters.",
+        )
     content = await file.read(MAX_FILE_BYTES + 1)
     parsed = parse_shipments_csv(
         content,
         content_type=media_type,
         filename=file.filename,
     )
+    artifact = None
     if parsed.rows:
-        _consume_analysis_run(workspace.workspace_id)
-        shipment_repository.replace_for_workspace(workspace.workspace_id, parsed.rows)
+        _consume_analysis_run(principal.workspace_id)
+        artifact = create_artifact(
+            workspace_id=principal.workspace_id,
+            kind=ArtifactKind.SHIPMENT_DATASET,
+            title=file.filename,
+            source_type=ArtifactSourceType.LOCAL_UPLOAD,
+            source_reference=file.filename,
+            media_type=media_type,
+            content_sha256=sha256(content).hexdigest(),
+            created_by=principal.subject,
+        )
+        artifact_repository.create(artifact)
+        try:
+            shipment_repository.replace_for_workspace(
+                principal.workspace_id,
+                artifact.artifact_id,
+                parsed.rows,
+            )
+            artifact = artifact_repository.mark_ready(
+                principal.workspace_id,
+                artifact.artifact_id,
+                {
+                    "accepted_rows": len(parsed.rows),
+                    "validation_error_count": len(parsed.errors),
+                    "warning_count": len(parsed.warnings),
+                },
+            )
+            artifact_repository.soft_delete_other_ready_shipments(
+                principal.workspace_id,
+                artifact.artifact_id,
+            )
+        except Exception:
+            artifact_repository.mark_failed(principal.workspace_id, artifact.artifact_id)
+            raise
     return _response(
         parsed.rows,
+        artifact=artifact,
         errors=tuple(error.to_dict() for error in parsed.errors),
         warnings=parsed.warnings,
     )
@@ -147,7 +192,15 @@ async def upload_shipments(
 
 @shipments_router.get("", response_model=ShipmentUploadResponse)
 async def list_shipments(
-    workspace: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
 ) -> ShipmentUploadResponse:
-    rows = shipment_repository.list_for_workspace(workspace.workspace_id)
-    return _response(rows)
+    rows = shipment_repository.list_for_workspace(principal.workspace_id)
+    artifact = next(
+        (
+            item
+            for item in artifact_repository.list_for_workspace(principal.workspace_id)
+            if item.kind is ArtifactKind.SHIPMENT_DATASET
+        ),
+        None,
+    )
+    return _response(rows, artifact=artifact)

--- a/nzeroesg-api/api/workspaces.py
+++ b/nzeroesg-api/api/workspaces.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 
 from config import database_url_for_runtime, settings
+from domain.workspaces.principals import WorkspacePrincipal
 from domain.workspaces.sessions import SessionError, SessionSigner, WorkspaceSession
 from persistence.workspaces import build_workspace_repository
 
@@ -59,6 +60,14 @@ async def require_workspace_session(
             detail=str(exc),
             headers={"WWW-Authenticate": "Cookie"},
         ) from exc
+
+
+async def require_workspace_principal(
+    session: Annotated[WorkspaceSession, Depends(require_workspace_session)],
+) -> WorkspacePrincipal:
+    """Resolve the dashboard cookie to the common application principal."""
+
+    return WorkspacePrincipal.from_demo_session(session)
 
 
 @workspace_router.post(

--- a/nzeroesg-api/domain/artifacts/__init__.py
+++ b/nzeroesg-api/domain/artifacts/__init__.py
@@ -1,0 +1,19 @@
+"""Workspace-owned source and decision artifact contracts."""
+
+from domain.artifacts.models import (
+    Artifact,
+    ArtifactKind,
+    ArtifactSourceType,
+    ArtifactStatus,
+    ReportSnapshot,
+    create_artifact,
+)
+
+__all__ = [
+    "Artifact",
+    "ArtifactKind",
+    "ArtifactSourceType",
+    "ArtifactStatus",
+    "ReportSnapshot",
+    "create_artifact",
+]

--- a/nzeroesg-api/domain/artifacts/models.py
+++ b/nzeroesg-api/domain/artifacts/models.py
@@ -1,0 +1,122 @@
+"""Framework-independent workspace artifact records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+from uuid import uuid4
+
+
+class ArtifactKind(StrEnum):
+    SHIPMENT_DATASET = "shipment_dataset"
+    EVIDENCE_DOCUMENT = "evidence_document"
+    REPORT_SNAPSHOT = "report_snapshot"
+
+
+class ArtifactStatus(StrEnum):
+    PROCESSING = "processing"
+    READY = "ready"
+    FAILED = "failed"
+
+
+class ArtifactSourceType(StrEnum):
+    LOCAL_UPLOAD = "local_upload"
+    GENERATED = "generated"
+    GOOGLE_DRIVE = "google_drive"
+    LEGACY_MIGRATION = "legacy_migration"
+
+
+def normalize_artifact_title(value: str) -> str:
+    title = " ".join(value.strip().split())
+    if not title:
+        raise ValueError("Artifact title is required.")
+    if len(title) > 255:
+        raise ValueError("Artifact title must contain at most 255 characters.")
+    return title
+
+
+@dataclass(frozen=True)
+class Artifact:
+    artifact_id: str
+    workspace_id: str
+    kind: ArtifactKind
+    title: str
+    status: ArtifactStatus
+    source_type: ArtifactSourceType
+    source_reference: str | None
+    media_type: str | None
+    content_sha256: str | None
+    version: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_by: str = "demo-session"
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    deleted_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        normalize_artifact_title(self.title)
+        if self.version < 1:
+            raise ValueError("Artifact version must be positive.")
+        if self.content_sha256 is not None and len(self.content_sha256) != 64:
+            raise ValueError("Artifact content hash must be a SHA-256 digest.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "workspace_id": self.workspace_id,
+            "kind": self.kind.value,
+            "title": self.title,
+            "status": self.status.value,
+            "source_type": self.source_type.value,
+            "source_reference": self.source_reference,
+            "media_type": self.media_type,
+            "content_sha256": self.content_sha256,
+            "version": self.version,
+            "metadata": dict(self.metadata),
+            "created_by": self.created_by,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "deleted_at": self.deleted_at.isoformat() if self.deleted_at else None,
+        }
+
+
+def create_artifact(
+    *,
+    workspace_id: str,
+    kind: ArtifactKind,
+    title: str,
+    source_type: ArtifactSourceType,
+    created_by: str,
+    source_reference: str | None = None,
+    media_type: str | None = None,
+    content_sha256: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Artifact:
+    now = datetime.now(UTC)
+    return Artifact(
+        artifact_id=str(uuid4()),
+        workspace_id=workspace_id,
+        kind=kind,
+        title=normalize_artifact_title(title),
+        status=ArtifactStatus.PROCESSING,
+        source_type=source_type,
+        source_reference=source_reference,
+        media_type=media_type,
+        content_sha256=content_sha256,
+        version=1,
+        metadata=dict(metadata or {}),
+        created_by=created_by,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@dataclass(frozen=True)
+class ReportSnapshot:
+    artifact_id: str
+    workspace_id: str
+    schema_version: str
+    payload: dict[str, Any]
+    generated_at: datetime

--- a/nzeroesg-api/domain/evidence/ingestion.py
+++ b/nzeroesg-api/domain/evidence/ingestion.py
@@ -111,6 +111,10 @@ def extract_evidence(
     content_type: str,
 ) -> EvidenceExtraction:
     """Extract bounded text from a TXT or text-based PDF upload."""
+    if not filename.strip() or len(filename) > 255:
+        raise EvidenceIngestionError(
+            "Evidence file name is required and must be 255 characters or fewer."
+        )
     if len(content) > MAX_FILE_BYTES:
         raise EvidenceIngestionError("Evidence file exceeds the 10 MB limit.")
     normalized_type = content_type.split(";", 1)[0].strip().lower()

--- a/nzeroesg-api/domain/evidence/models.py
+++ b/nzeroesg-api/domain/evidence/models.py
@@ -53,6 +53,7 @@ class SupplierCard:
 
 @dataclass(frozen=True)
 class EvidenceMatch:
+    artifact_id: str
     supplier_name: str
     filename: str
     excerpt: str
@@ -74,6 +75,7 @@ class EvidenceMatch:
             "filename": self.filename,
             "excerpt": self.excerpt,
             "citation": {
+                "artifact_id": self.artifact_id,
                 "page_number": self.page_number,
                 "chunk_index": self.chunk_index,
                 "document_sha256": self.document_sha256,

--- a/nzeroesg-api/domain/workspaces/principals.py
+++ b/nzeroesg-api/domain/workspaces/principals.py
@@ -1,0 +1,49 @@
+"""Common authorization principal for dashboard and future embed access."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from domain.workspaces.sessions import WorkspaceSession
+
+
+class AuthenticationMethod(StrEnum):
+    DEMO_SESSION = "demo_session"
+    EMBED_TOKEN = "embed_token"
+
+
+DASHBOARD_SCOPES = (
+    "artifacts:read",
+    "artifacts:write",
+    "evidence:read",
+    "evidence:write",
+    "shipments:read",
+    "shipments:write",
+    "reports:read",
+    "reports:write",
+)
+
+
+@dataclass(frozen=True)
+class WorkspacePrincipal:
+    workspace_id: str
+    subject: str
+    audience: str
+    authentication_method: AuthenticationMethod
+    scopes: tuple[str, ...]
+    expires_at: int
+
+    def allows(self, scope: str) -> bool:
+        return scope in self.scopes
+
+    @classmethod
+    def from_demo_session(cls, session: WorkspaceSession) -> WorkspacePrincipal:
+        return cls(
+            workspace_id=session.workspace_id,
+            subject=f"demo:{session.workspace_id}",
+            audience="carbonsage-dashboard",
+            authentication_method=AuthenticationMethod.DEMO_SESSION,
+            scopes=DASHBOARD_SCOPES,
+            expires_at=session.expires_at,
+        )

--- a/nzeroesg-api/main.py
+++ b/nzeroesg-api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
+from api.artifacts import artifacts_router
 from api.emissions import emissions_router
 from api.evidence import evidence_router
 from api.reports import reports_router
@@ -13,14 +14,14 @@ from config import settings
 app = FastAPI(
     title="CarbonSage API",
     description="Evidence-grounded Scope 3 intelligence and deterministic decision tools.",
-    version="0.2.0-dev",
+    version="0.3.0-dev",
 )
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=list(settings.cors_origins),
     allow_credentials=True,
-    allow_methods=["GET", "POST", "DELETE"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE"],
     allow_headers=["Content-Type"],
 )
 
@@ -41,6 +42,7 @@ async def add_security_headers(request: Request, call_next):
 
 app.include_router(chat_router, prefix="/chat", tags=["chat"])
 app.include_router(workspace_router)
+app.include_router(artifacts_router)
 app.include_router(emissions_router)
 app.include_router(shipments_router)
 app.include_router(evidence_router)

--- a/nzeroesg-api/persistence/artifacts.py
+++ b/nzeroesg-api/persistence/artifacts.py
@@ -1,0 +1,414 @@
+"""Workspace-scoped artifact catalog and report-snapshot persistence."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import closing
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+try:
+    import psycopg
+    from psycopg.types.json import Jsonb
+except ImportError:  # pragma: no cover - exercised only before optional local setup
+    psycopg = None
+    Jsonb = None
+
+from domain.artifacts.models import (
+    Artifact,
+    ArtifactKind,
+    ArtifactSourceType,
+    ArtifactStatus,
+    ReportSnapshot,
+    normalize_artifact_title,
+)
+
+
+class ArtifactNotFoundError(LookupError):
+    """Raised when an active artifact is absent from the selected workspace."""
+
+
+class ArtifactRepository(Protocol):
+    def create(self, artifact: Artifact) -> Artifact: ...
+
+    def get(self, workspace_id: str, artifact_id: str) -> Artifact | None: ...
+
+    def list_for_workspace(self, workspace_id: str) -> tuple[Artifact, ...]: ...
+
+    def rename(self, workspace_id: str, artifact_id: str, title: str) -> Artifact: ...
+
+    def mark_ready(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        metadata: dict[str, Any],
+    ) -> Artifact: ...
+
+    def mark_failed(self, workspace_id: str, artifact_id: str) -> Artifact: ...
+
+    def soft_delete(self, workspace_id: str, artifact_id: str) -> Artifact: ...
+
+    def soft_delete_other_ready_shipments(
+        self,
+        workspace_id: str,
+        keep_artifact_id: str,
+    ) -> int: ...
+
+
+class ReportSnapshotRepository(Protocol):
+    def store(self, snapshot: ReportSnapshot) -> None: ...
+
+    def get(self, workspace_id: str, artifact_id: str) -> ReportSnapshot | None: ...
+
+
+def _clone_artifact(artifact: Artifact) -> Artifact:
+    return replace(artifact, metadata=dict(artifact.metadata))
+
+
+class InMemoryArtifactRepository:
+    """Credential-free artifact catalog used by local development and unit tests."""
+
+    def __init__(self) -> None:
+        self._artifacts: dict[tuple[str, str], Artifact] = {}
+        self._lock = threading.RLock()
+
+    def create(self, artifact: Artifact) -> Artifact:
+        key = (artifact.workspace_id, artifact.artifact_id)
+        with self._lock:
+            if key in self._artifacts:
+                raise ValueError("Artifact already exists.")
+            self._artifacts[key] = _clone_artifact(artifact)
+        return _clone_artifact(artifact)
+
+    def get(self, workspace_id: str, artifact_id: str) -> Artifact | None:
+        with self._lock:
+            artifact = self._artifacts.get((workspace_id, artifact_id))
+            if artifact is None or artifact.deleted_at is not None:
+                return None
+            return _clone_artifact(artifact)
+
+    def list_for_workspace(self, workspace_id: str) -> tuple[Artifact, ...]:
+        with self._lock:
+            artifacts = [
+                _clone_artifact(artifact)
+                for (record_workspace, _), artifact in self._artifacts.items()
+                if record_workspace == workspace_id and artifact.deleted_at is None
+            ]
+        return tuple(sorted(artifacts, key=lambda artifact: artifact.created_at, reverse=True))
+
+    def _update(self, workspace_id: str, artifact_id: str, **changes: Any) -> Artifact:
+        key = (workspace_id, artifact_id)
+        with self._lock:
+            current = self._artifacts.get(key)
+            if current is None or current.deleted_at is not None:
+                raise ArtifactNotFoundError(artifact_id)
+            updated = replace(current, updated_at=datetime.now(UTC), **changes)
+            self._artifacts[key] = updated
+            return _clone_artifact(updated)
+
+    def rename(self, workspace_id: str, artifact_id: str, title: str) -> Artifact:
+        return self._update(
+            workspace_id,
+            artifact_id,
+            title=normalize_artifact_title(title),
+        )
+
+    def mark_ready(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        metadata: dict[str, Any],
+    ) -> Artifact:
+        return self._update(
+            workspace_id,
+            artifact_id,
+            status=ArtifactStatus.READY,
+            metadata=dict(metadata),
+        )
+
+    def mark_failed(self, workspace_id: str, artifact_id: str) -> Artifact:
+        return self._update(workspace_id, artifact_id, status=ArtifactStatus.FAILED)
+
+    def soft_delete(self, workspace_id: str, artifact_id: str) -> Artifact:
+        now = datetime.now(UTC)
+        return self._update(workspace_id, artifact_id, deleted_at=now)
+
+    def soft_delete_other_ready_shipments(
+        self,
+        workspace_id: str,
+        keep_artifact_id: str,
+    ) -> int:
+        deleted = 0
+        with self._lock:
+            for key, artifact in tuple(self._artifacts.items()):
+                if (
+                    artifact.workspace_id == workspace_id
+                    and artifact.artifact_id != keep_artifact_id
+                    and artifact.kind is ArtifactKind.SHIPMENT_DATASET
+                    and artifact.deleted_at is None
+                ):
+                    now = datetime.now(UTC)
+                    self._artifacts[key] = replace(artifact, deleted_at=now, updated_at=now)
+                    deleted += 1
+        return deleted
+
+
+def _artifact_from_row(row: tuple[Any, ...]) -> Artifact:
+    return Artifact(
+        artifact_id=str(row[0]),
+        workspace_id=row[1],
+        kind=ArtifactKind(row[2]),
+        title=row[3],
+        status=ArtifactStatus(row[4]),
+        source_type=ArtifactSourceType(row[5]),
+        source_reference=row[6],
+        media_type=row[7],
+        content_sha256=row[8],
+        version=row[9],
+        metadata=dict(row[10] or {}),
+        created_by=row[11],
+        created_at=row[12],
+        updated_at=row[13],
+        deleted_at=row[14],
+    )
+
+
+ARTIFACT_COLUMNS = """
+    artifact_id, workspace_id, kind, title, status, source_type,
+    source_reference, media_type, content_sha256, version, metadata,
+    created_by, created_at, updated_at, deleted_at
+"""
+
+
+class PostgresArtifactRepository:
+    """PostgreSQL artifact catalog with mandatory workspace predicates."""
+
+    def __init__(self, database_url: str) -> None:
+        if psycopg is None or Jsonb is None:
+            raise RuntimeError("psycopg is required when DATABASE_URL is configured.")
+        self.database_url = database_url
+
+    def _connect(self):
+        return psycopg.connect(self.database_url)
+
+    def create(self, artifact: Artifact) -> Artifact:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    INSERT INTO artifacts ({ARTIFACT_COLUMNS})
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                            %s, %s, %s, %s, %s)
+                    RETURNING {ARTIFACT_COLUMNS}
+                    """,
+                    (
+                        artifact.artifact_id,
+                        artifact.workspace_id,
+                        artifact.kind.value,
+                        artifact.title,
+                        artifact.status.value,
+                        artifact.source_type.value,
+                        artifact.source_reference,
+                        artifact.media_type,
+                        artifact.content_sha256,
+                        artifact.version,
+                        Jsonb(artifact.metadata),
+                        artifact.created_by,
+                        artifact.created_at,
+                        artifact.updated_at,
+                        artifact.deleted_at,
+                    ),
+                )
+                row = cursor.fetchone()
+            connection.commit()
+        return _artifact_from_row(row)
+
+    def get(self, workspace_id: str, artifact_id: str) -> Artifact | None:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT {ARTIFACT_COLUMNS}
+                    FROM artifacts
+                    WHERE workspace_id = %s AND artifact_id = %s AND deleted_at IS NULL
+                    """,
+                    (workspace_id, artifact_id),
+                )
+                row = cursor.fetchone()
+        return _artifact_from_row(row) if row else None
+
+    def list_for_workspace(self, workspace_id: str) -> tuple[Artifact, ...]:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT {ARTIFACT_COLUMNS}
+                    FROM artifacts
+                    WHERE workspace_id = %s AND deleted_at IS NULL
+                    ORDER BY created_at DESC, artifact_id
+                    """,
+                    (workspace_id,),
+                )
+                rows = cursor.fetchall()
+        return tuple(_artifact_from_row(row) for row in rows)
+
+    def _update(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        assignments: str,
+        values: tuple[Any, ...],
+    ) -> Artifact:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    UPDATE artifacts
+                    SET {assignments}, updated_at = CURRENT_TIMESTAMP
+                    WHERE workspace_id = %s AND artifact_id = %s AND deleted_at IS NULL
+                    RETURNING {ARTIFACT_COLUMNS}
+                    """,
+                    (*values, workspace_id, artifact_id),
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    connection.rollback()
+                    raise ArtifactNotFoundError(artifact_id)
+            connection.commit()
+        return _artifact_from_row(row)
+
+    def rename(self, workspace_id: str, artifact_id: str, title: str) -> Artifact:
+        return self._update(
+            workspace_id,
+            artifact_id,
+            "title = %s",
+            (normalize_artifact_title(title),),
+        )
+
+    def mark_ready(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        metadata: dict[str, Any],
+    ) -> Artifact:
+        return self._update(
+            workspace_id,
+            artifact_id,
+            "status = 'ready', metadata = %s",
+            (Jsonb(metadata),),
+        )
+
+    def mark_failed(self, workspace_id: str, artifact_id: str) -> Artifact:
+        return self._update(workspace_id, artifact_id, "status = 'failed'", ())
+
+    def soft_delete(self, workspace_id: str, artifact_id: str) -> Artifact:
+        return self._update(
+            workspace_id,
+            artifact_id,
+            "deleted_at = CURRENT_TIMESTAMP",
+            (),
+        )
+
+    def soft_delete_other_ready_shipments(
+        self,
+        workspace_id: str,
+        keep_artifact_id: str,
+    ) -> int:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE artifacts
+                    SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+                    WHERE workspace_id = %s
+                      AND kind = 'shipment_dataset'
+                      AND artifact_id <> %s
+                      AND deleted_at IS NULL
+                    """,
+                    (workspace_id, keep_artifact_id),
+                )
+                deleted = cursor.rowcount
+            connection.commit()
+        return deleted
+
+
+class InMemoryReportSnapshotRepository:
+    def __init__(self) -> None:
+        self._snapshots: dict[tuple[str, str], ReportSnapshot] = {}
+        self._lock = threading.RLock()
+
+    def store(self, snapshot: ReportSnapshot) -> None:
+        with self._lock:
+            self._snapshots[(snapshot.workspace_id, snapshot.artifact_id)] = replace(
+                snapshot,
+                payload=dict(snapshot.payload),
+            )
+
+    def get(self, workspace_id: str, artifact_id: str) -> ReportSnapshot | None:
+        with self._lock:
+            snapshot = self._snapshots.get((workspace_id, artifact_id))
+            return replace(snapshot, payload=dict(snapshot.payload)) if snapshot else None
+
+
+class PostgresReportSnapshotRepository:
+    def __init__(self, database_url: str) -> None:
+        if psycopg is None or Jsonb is None:
+            raise RuntimeError("psycopg is required when DATABASE_URL is configured.")
+        self.database_url = database_url
+
+    def _connect(self):
+        return psycopg.connect(self.database_url)
+
+    def store(self, snapshot: ReportSnapshot) -> None:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO report_snapshots
+                        (artifact_id, workspace_id, schema_version, payload, generated_at)
+                    VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (
+                        snapshot.artifact_id,
+                        snapshot.workspace_id,
+                        snapshot.schema_version,
+                        Jsonb(snapshot.payload),
+                        snapshot.generated_at,
+                    ),
+                )
+            connection.commit()
+
+    def get(self, workspace_id: str, artifact_id: str) -> ReportSnapshot | None:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT artifact_id, workspace_id, schema_version, payload, generated_at
+                    FROM report_snapshots
+                    WHERE workspace_id = %s AND artifact_id = %s
+                    """,
+                    (workspace_id, artifact_id),
+                )
+                row = cursor.fetchone()
+        if row is None:
+            return None
+        return ReportSnapshot(
+            artifact_id=str(row[0]),
+            workspace_id=row[1],
+            schema_version=row[2],
+            payload=dict(row[3]),
+            generated_at=row[4],
+        )
+
+
+def build_artifact_repository(database_url: str | None) -> ArtifactRepository:
+    if database_url:
+        return PostgresArtifactRepository(database_url)
+    return InMemoryArtifactRepository()
+
+
+def build_report_snapshot_repository(database_url: str | None) -> ReportSnapshotRepository:
+    if database_url:
+        return PostgresReportSnapshotRepository(database_url)
+    return InMemoryReportSnapshotRepository()

--- a/nzeroesg-api/persistence/evidence.py
+++ b/nzeroesg-api/persistence/evidence.py
@@ -33,11 +33,14 @@ class EvidenceRepository(Protocol):
     def store(
         self,
         workspace_id: str,
+        artifact_id: str,
         supplier: SupplierMetadata,
         document: EvidenceDocument,
     ) -> SupplierCard: ...
 
     def list_suppliers(self, workspace_id: str) -> tuple[SupplierCard, ...]: ...
+
+    def has_document(self, workspace_id: str, document_sha256: str) -> bool: ...
 
     def store_embeddings(
         self,
@@ -61,6 +64,8 @@ class EvidenceRepository(Protocol):
         query_embedding: tuple[float, ...],
         spec: EmbeddingSpec,
     ) -> tuple[EvidenceMatch, ...]: ...
+
+    def delete_for_artifact(self, workspace_id: str, artifact_id: str) -> int: ...
 
 
 def _vector_literal(values: tuple[float, ...]) -> str:
@@ -118,12 +123,16 @@ class InMemoryEvidenceRepository:
 
     def __init__(self) -> None:
         self._suppliers: dict[tuple[str, str], tuple[str, SupplierMetadata, int]] = {}
-        self._documents: dict[tuple[str, str], tuple[str, SupplierMetadata, EvidenceDocument]] = {}
+        self._documents: dict[
+            tuple[str, str],
+            tuple[str, str, SupplierMetadata, EvidenceDocument],
+        ] = {}
         self._embeddings: dict[tuple[str, str, int, str, str], ChunkEmbedding] = {}
 
     def store(
         self,
         workspace_id: str,
+        artifact_id: str,
         supplier: SupplierMetadata,
         document: EvidenceDocument,
     ) -> SupplierCard:
@@ -134,7 +143,7 @@ class InMemoryEvidenceRepository:
         )
         document_key = (workspace_id, document.sha256)
         if document_key not in self._documents:
-            self._documents[document_key] = (supplier_id, supplier, document)
+            self._documents[document_key] = (artifact_id, supplier_id, supplier, document)
             document_count += 1
         self._suppliers[supplier_key] = (supplier_id, supplier, document_count)
         return _card(supplier_id=supplier_id, supplier=supplier, document_count=document_count)
@@ -151,6 +160,9 @@ class InMemoryEvidenceRepository:
         ]
         return tuple(sorted(cards, key=lambda card: card.name.casefold()))
 
+    def has_document(self, workspace_id: str, document_sha256: str) -> bool:
+        return (workspace_id, document_sha256) in self._documents
+
     def store_embeddings(
         self,
         workspace_id: str,
@@ -161,7 +173,7 @@ class InMemoryEvidenceRepository:
         document_record = self._documents.get((workspace_id, document_sha256))
         if document_record is None:
             raise ValueError("Evidence document was not found in this workspace.")
-        document = document_record[2]
+        document = document_record[3]
         chunks_by_index = {chunk.chunk_index: chunk for chunk in document.chunks}
         for embedding in embeddings:
             chunk = chunks_by_index.get(embedding.chunk_index)
@@ -189,6 +201,7 @@ class InMemoryEvidenceRepository:
     ) -> tuple[PendingEmbeddingDocument, ...]:
         pending: list[PendingEmbeddingDocument] = []
         for (record_workspace, document_sha), (
+            _artifact_id,
             _supplier_id,
             _supplier,
             document,
@@ -219,7 +232,12 @@ class InMemoryEvidenceRepository:
     def search_lexical(self, workspace_id: str, query: str) -> tuple[EvidenceMatch, ...]:
         terms = {term.casefold() for term in query.split() if term.strip()}
         matches: list[tuple[int, EvidenceMatch]] = []
-        for (record_workspace, _), (_supplier_id, supplier, document) in self._documents.items():
+        for (record_workspace, _), (
+            artifact_id,
+            _supplier_id,
+            supplier,
+            document,
+        ) in self._documents.items():
             if record_workspace != workspace_id:
                 continue
             for chunk in document.chunks:
@@ -230,6 +248,7 @@ class InMemoryEvidenceRepository:
                         (
                             score,
                             EvidenceMatch(
+                                artifact_id=artifact_id,
                                 supplier_name=supplier.name,
                                 filename=document.filename,
                                 excerpt=chunk.content,
@@ -258,6 +277,7 @@ class InMemoryEvidenceRepository:
         validated_query = validate_vector(query_embedding, spec.dimensions)
         matches: list[EvidenceMatch] = []
         for (record_workspace, document_sha), (
+            artifact_id,
             _supplier_id,
             supplier,
             document,
@@ -278,6 +298,7 @@ class InMemoryEvidenceRepository:
                     continue
                 matches.append(
                     EvidenceMatch(
+                        artifact_id=artifact_id,
                         supplier_name=supplier.name,
                         filename=document.filename,
                         excerpt=chunk.content,
@@ -305,6 +326,31 @@ class InMemoryEvidenceRepository:
 
         return self.search_lexical(workspace_id, query)
 
+    def delete_for_artifact(self, workspace_id: str, artifact_id: str) -> int:
+        matching_keys = [
+            key
+            for key, record in self._documents.items()
+            if key[0] == workspace_id and record[0] == artifact_id
+        ]
+        for key in matching_keys:
+            _artifact_id, supplier_id, supplier, document = self._documents.pop(key)
+            for embedding_key in tuple(self._embeddings):
+                if embedding_key[0] == workspace_id and embedding_key[1] == document.sha256:
+                    del self._embeddings[embedding_key]
+            supplier_key = (workspace_id, supplier.name.casefold())
+            remaining = sum(
+                1
+                for record_workspace, _document_sha in self._documents
+                if record_workspace == workspace_id
+                and self._documents[(record_workspace, _document_sha)][1] == supplier_id
+            )
+            if remaining:
+                current = self._suppliers[supplier_key]
+                self._suppliers[supplier_key] = (current[0], current[1], remaining)
+            else:
+                self._suppliers.pop(supplier_key, None)
+        return len(matching_keys)
+
 
 class PostgresEvidenceRepository:
     """PostgreSQL lexical and pgvector evidence repository."""
@@ -320,6 +366,7 @@ class PostgresEvidenceRepository:
     def store(
         self,
         workspace_id: str,
+        artifact_id: str,
         supplier: SupplierMetadata,
         document: EvidenceDocument,
     ) -> SupplierCard:
@@ -360,13 +407,14 @@ class PostgresEvidenceRepository:
                     cursor.execute(
                         """
                         INSERT INTO evidence_documents
-                            (document_id, workspace_id, supplier_id, filename, media_type,
-                             sha256, page_count, extracted_chars)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                            (document_id, workspace_id, artifact_id, supplier_id,
+                             filename, media_type, sha256, page_count, extracted_chars)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                         """,
                         (
                             document_id,
                             workspace_id,
+                            artifact_id,
                             supplier_id,
                             document.filename,
                             document.media_type,
@@ -413,13 +461,18 @@ class PostgresEvidenceRepository:
                 cursor.execute(
                     """
                     SELECT s.supplier_id, s.name, s.region, s.certifications,
-                           s.transport_modes, COUNT(d.document_id)
+                           s.transport_modes, COUNT(a.artifact_id)
                     FROM suppliers AS s
                     LEFT JOIN evidence_documents AS d
                         ON d.supplier_id = s.supplier_id
                        AND d.workspace_id = s.workspace_id
+                    LEFT JOIN artifacts AS a
+                        ON a.artifact_id = d.artifact_id
+                       AND a.workspace_id = d.workspace_id
+                       AND a.deleted_at IS NULL
                     WHERE s.workspace_id = %s
                     GROUP BY s.supplier_id, s.name, s.region, s.certifications, s.transport_modes
+                    HAVING COUNT(a.artifact_id) > 0
                     ORDER BY s.name
                     """,
                     (workspace_id,),
@@ -439,6 +492,23 @@ class PostgresEvidenceRepository:
             for row in rows
         )
 
+    def has_document(self, workspace_id: str, document_sha256: str) -> bool:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT 1
+                    FROM evidence_documents AS document
+                    JOIN artifacts AS artifact
+                      ON artifact.artifact_id = document.artifact_id
+                     AND artifact.workspace_id = document.workspace_id
+                     AND artifact.deleted_at IS NULL
+                    WHERE document.workspace_id = %s AND document.sha256 = %s
+                    """,
+                    (workspace_id, document_sha256),
+                )
+                return cursor.fetchone() is not None
+
     def store_embeddings(
         self,
         workspace_id: str,
@@ -457,6 +527,10 @@ class PostgresEvidenceRepository:
                     JOIN evidence_documents AS d
                         ON d.document_id = c.document_id
                        AND d.workspace_id = c.workspace_id
+                    JOIN artifacts AS a
+                        ON a.artifact_id = d.artifact_id
+                       AND a.workspace_id = d.workspace_id
+                       AND a.deleted_at IS NULL
                     WHERE c.workspace_id = %s AND d.sha256 = %s
                     ORDER BY c.chunk_index
                     """,
@@ -521,6 +595,10 @@ class PostgresEvidenceRepository:
                     JOIN evidence_chunks AS c
                         ON c.document_id = d.document_id
                        AND c.workspace_id = d.workspace_id
+                    JOIN artifacts AS a
+                        ON a.artifact_id = d.artifact_id
+                       AND a.workspace_id = d.workspace_id
+                       AND a.deleted_at IS NULL
                     LEFT JOIN evidence_chunk_embeddings AS e
                         ON e.chunk_id = c.chunk_id
                        AND e.workspace_id = c.workspace_id
@@ -564,7 +642,7 @@ class PostgresEvidenceRepository:
                             ' | '
                         )::tsquery AS value
                     )
-                    SELECT s.name, d.filename, c.content, c.page_number,
+                    SELECT d.artifact_id, s.name, d.filename, c.content, c.page_number,
                            c.chunk_index, d.sha256,
                            ts_rank(c.search_vector, lexical_query.value) AS rank
                     FROM evidence_chunks AS c
@@ -574,6 +652,10 @@ class PostgresEvidenceRepository:
                     JOIN suppliers AS s
                         ON s.supplier_id = c.supplier_id
                        AND s.workspace_id = c.workspace_id
+                    JOIN artifacts AS a
+                        ON a.artifact_id = d.artifact_id
+                       AND a.workspace_id = d.workspace_id
+                       AND a.deleted_at IS NULL
                     CROSS JOIN lexical_query
                     WHERE c.workspace_id = %s
                       AND c.search_vector @@ lexical_query.value
@@ -585,13 +667,14 @@ class PostgresEvidenceRepository:
                 rows = cursor.fetchall()
         matches = tuple(
             EvidenceMatch(
-                supplier_name=row[0],
-                filename=row[1],
-                excerpt=row[2],
-                page_number=row[3],
-                chunk_index=row[4],
-                document_sha256=row[5],
-                score=float(row[6]),
+                artifact_id=str(row[0]),
+                supplier_name=row[1],
+                filename=row[2],
+                excerpt=row[3],
+                page_number=row[4],
+                chunk_index=row[5],
+                document_sha256=row[6],
+                score=float(row[7]),
             )
             for row in rows
         )
@@ -608,7 +691,7 @@ class PostgresEvidenceRepository:
             with connection.cursor() as cursor:
                 cursor.execute(
                     """
-                    SELECT s.name, d.filename, c.content, c.page_number,
+                    SELECT d.artifact_id, s.name, d.filename, c.content, c.page_number,
                            c.chunk_index, d.sha256,
                            1 - (e.embedding <=> %s::vector) AS similarity
                     FROM evidence_chunk_embeddings AS e
@@ -621,6 +704,10 @@ class PostgresEvidenceRepository:
                     JOIN suppliers AS s
                         ON s.supplier_id = c.supplier_id
                        AND s.workspace_id = c.workspace_id
+                    JOIN artifacts AS a
+                        ON a.artifact_id = d.artifact_id
+                       AND a.workspace_id = d.workspace_id
+                       AND a.deleted_at IS NULL
                     WHERE e.workspace_id = %s
                       AND e.provider = %s
                       AND e.model = %s
@@ -640,14 +727,15 @@ class PostgresEvidenceRepository:
                 rows = cursor.fetchall()
         matches = tuple(
             EvidenceMatch(
-                supplier_name=row[0],
-                filename=row[1],
-                excerpt=row[2],
-                page_number=row[3],
-                chunk_index=row[4],
-                document_sha256=row[5],
+                artifact_id=str(row[0]),
+                supplier_name=row[1],
+                filename=row[2],
+                excerpt=row[3],
+                page_number=row[4],
+                chunk_index=row[5],
+                document_sha256=row[6],
                 retrieval_mode=RetrievalMode.SEMANTIC.value,
-                score=float(row[6]),
+                score=float(row[7]),
             )
             for row in rows
         )
@@ -657,6 +745,35 @@ class PostgresEvidenceRepository:
         """Compatibility alias for the lexical baseline."""
 
         return self.search_lexical(workspace_id, query)
+
+    def delete_for_artifact(self, workspace_id: str, artifact_id: str) -> int:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM evidence_documents
+                    WHERE workspace_id = %s AND artifact_id = %s
+                    RETURNING supplier_id
+                    """,
+                    (workspace_id, artifact_id),
+                )
+                supplier_ids = [row[0] for row in cursor.fetchall()]
+                for supplier_id in supplier_ids:
+                    cursor.execute(
+                        """
+                        DELETE FROM suppliers AS supplier
+                        WHERE supplier.workspace_id = %s
+                          AND supplier.supplier_id = %s
+                          AND NOT EXISTS (
+                              SELECT 1 FROM evidence_documents AS document
+                              WHERE document.workspace_id = supplier.workspace_id
+                                AND document.supplier_id = supplier.supplier_id
+                          )
+                        """,
+                        (workspace_id, supplier_id),
+                    )
+            connection.commit()
+        return len(supplier_ids)
 
 
 def build_evidence_repository(database_url: str | None) -> EvidenceRepository:

--- a/nzeroesg-api/persistence/migrations/005_artifact_catalog.sql
+++ b/nzeroesg-api/persistence/migrations/005_artifact_catalog.sql
@@ -1,0 +1,98 @@
+CREATE TABLE artifacts (
+    artifact_id UUID PRIMARY KEY,
+    workspace_id VARCHAR(80) NOT NULL REFERENCES workspaces(workspace_id) ON DELETE CASCADE,
+    kind VARCHAR(40) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    status VARCHAR(30) NOT NULL,
+    source_type VARCHAR(40) NOT NULL,
+    source_reference VARCHAR(500),
+    media_type VARCHAR(100),
+    content_sha256 CHAR(64),
+    version INTEGER NOT NULL DEFAULT 1,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_by VARCHAR(160) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMPTZ,
+    UNIQUE (workspace_id, artifact_id),
+    CONSTRAINT artifacts_kind CHECK (
+        kind IN ('shipment_dataset', 'evidence_document', 'report_snapshot')
+    ),
+    CONSTRAINT artifacts_status CHECK (status IN ('processing', 'ready', 'failed')),
+    CONSTRAINT artifacts_source_type CHECK (
+        source_type IN ('local_upload', 'generated', 'google_drive', 'legacy_migration')
+    ),
+    CONSTRAINT artifacts_version_positive CHECK (version > 0),
+    CONSTRAINT artifacts_title_present CHECK (length(btrim(title)) > 0)
+);
+
+CREATE INDEX artifacts_workspace_active_idx
+    ON artifacts (workspace_id, created_at DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX artifacts_workspace_kind_idx
+    ON artifacts (workspace_id, kind, created_at DESC);
+
+ALTER TABLE shipments ADD COLUMN artifact_id UUID;
+ALTER TABLE evidence_documents ADD COLUMN artifact_id UUID;
+
+INSERT INTO artifacts (
+    artifact_id, workspace_id, kind, title, status, source_type,
+    source_reference, media_type, version, metadata, created_by
+)
+SELECT
+    gen_random_uuid(), workspace_id, 'shipment_dataset', 'Existing shipment dataset',
+    'ready', 'legacy_migration', 'migration-005', 'text/csv', 1,
+    jsonb_build_object('migrated', true), 'migration-005'
+FROM shipments
+GROUP BY workspace_id;
+
+UPDATE shipments AS shipment
+SET artifact_id = artifact.artifact_id
+FROM artifacts AS artifact
+WHERE artifact.workspace_id = shipment.workspace_id
+  AND artifact.kind = 'shipment_dataset'
+  AND artifact.source_type = 'legacy_migration';
+
+INSERT INTO artifacts (
+    artifact_id, workspace_id, kind, title, status, source_type,
+    source_reference, media_type, content_sha256, version, metadata, created_by,
+    created_at, updated_at
+)
+SELECT
+    document_id, workspace_id, 'evidence_document', filename, 'ready',
+    'legacy_migration', filename, media_type, sha256, 1,
+    jsonb_build_object('migrated', true), 'migration-005', created_at, created_at
+FROM evidence_documents;
+
+UPDATE evidence_documents SET artifact_id = document_id;
+
+ALTER TABLE shipments ALTER COLUMN artifact_id SET NOT NULL;
+ALTER TABLE evidence_documents ALTER COLUMN artifact_id SET NOT NULL;
+
+ALTER TABLE shipments
+    ADD CONSTRAINT shipments_workspace_artifact_fk
+    FOREIGN KEY (workspace_id, artifact_id)
+    REFERENCES artifacts(workspace_id, artifact_id) ON DELETE CASCADE;
+
+ALTER TABLE evidence_documents
+    ADD CONSTRAINT evidence_documents_workspace_artifact_fk
+    FOREIGN KEY (workspace_id, artifact_id)
+    REFERENCES artifacts(workspace_id, artifact_id) ON DELETE CASCADE;
+
+CREATE INDEX shipments_artifact_idx ON shipments (workspace_id, artifact_id);
+CREATE INDEX evidence_documents_artifact_idx
+    ON evidence_documents (workspace_id, artifact_id);
+
+CREATE TABLE report_snapshots (
+    artifact_id UUID PRIMARY KEY REFERENCES artifacts(artifact_id) ON DELETE CASCADE,
+    workspace_id VARCHAR(80) NOT NULL REFERENCES workspaces(workspace_id) ON DELETE CASCADE,
+    schema_version VARCHAR(20) NOT NULL,
+    payload JSONB NOT NULL,
+    generated_at TIMESTAMPTZ NOT NULL,
+    FOREIGN KEY (workspace_id, artifact_id)
+        REFERENCES artifacts(workspace_id, artifact_id) ON DELETE CASCADE
+);
+
+CREATE INDEX report_snapshots_workspace_idx
+    ON report_snapshots (workspace_id, generated_at DESC);

--- a/nzeroesg-api/persistence/shipments.py
+++ b/nzeroesg-api/persistence/shipments.py
@@ -18,10 +18,13 @@ class ShipmentRepository(Protocol):
     def replace_for_workspace(
         self,
         workspace_id: str,
+        artifact_id: str,
         shipments: tuple[NormalizedShipment, ...],
     ) -> None: ...
 
     def list_for_workspace(self, workspace_id: str) -> tuple[NormalizedShipment, ...]: ...
+
+    def delete_for_artifact(self, workspace_id: str, artifact_id: str) -> int: ...
 
 
 def _clone(shipment: NormalizedShipment) -> NormalizedShipment:
@@ -40,17 +43,32 @@ class InMemoryShipmentRepository:
     """Non-persistent local fallback keyed by workspace id."""
 
     def __init__(self) -> None:
-        self._shipments: dict[str, tuple[NormalizedShipment, ...]] = {}
+        self._shipments: dict[str, tuple[str, tuple[NormalizedShipment, ...]]] = {}
 
     def replace_for_workspace(
         self,
         workspace_id: str,
+        artifact_id: str,
         shipments: tuple[NormalizedShipment, ...],
     ) -> None:
-        self._shipments[workspace_id] = tuple(_clone(shipment) for shipment in shipments)
+        self._shipments[workspace_id] = (
+            artifact_id,
+            tuple(_clone(shipment) for shipment in shipments),
+        )
 
     def list_for_workspace(self, workspace_id: str) -> tuple[NormalizedShipment, ...]:
-        return tuple(_clone(shipment) for shipment in self._shipments.get(workspace_id, ()))
+        record = self._shipments.get(workspace_id)
+        if record is None:
+            return ()
+        return tuple(_clone(shipment) for shipment in record[1])
+
+    def delete_for_artifact(self, workspace_id: str, artifact_id: str) -> int:
+        record = self._shipments.get(workspace_id)
+        if record is None or record[0] != artifact_id:
+            return 0
+        deleted = len(record[1])
+        del self._shipments[workspace_id]
+        return deleted
 
 
 class PostgresShipmentRepository:
@@ -67,6 +85,7 @@ class PostgresShipmentRepository:
     def replace_for_workspace(
         self,
         workspace_id: str,
+        artifact_id: str,
         shipments: tuple[NormalizedShipment, ...],
     ) -> None:
         with closing(self._connect()) as connection:
@@ -75,14 +94,15 @@ class PostgresShipmentRepository:
                 cursor.executemany(
                     """
                     INSERT INTO shipments
-                        (record_id, workspace_id, shipment_id, origin, destination,
+                        (record_id, workspace_id, artifact_id, shipment_id, origin, destination,
                          weight_kg, distance_km, transport_method, source_row)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     [
                         (
                             str(uuid4()),
                             workspace_id,
+                            artifact_id,
                             shipment.shipment_id,
                             shipment.origin,
                             shipment.destination,
@@ -103,8 +123,12 @@ class PostgresShipmentRepository:
                     """
                     SELECT shipment_id, origin, destination, weight_kg, distance_km,
                            transport_method, source_row
-                    FROM shipments
-                    WHERE workspace_id = %s
+                    FROM shipments AS shipment
+                    JOIN artifacts AS artifact
+                      ON artifact.artifact_id = shipment.artifact_id
+                     AND artifact.workspace_id = shipment.workspace_id
+                     AND artifact.deleted_at IS NULL
+                    WHERE shipment.workspace_id = %s
                     ORDER BY source_row, record_id
                     """,
                     (workspace_id,),
@@ -122,6 +146,20 @@ class PostgresShipmentRepository:
             )
             for row in rows
         )
+
+    def delete_for_artifact(self, workspace_id: str, artifact_id: str) -> int:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM shipments
+                    WHERE workspace_id = %s AND artifact_id = %s
+                    """,
+                    (workspace_id, artifact_id),
+                )
+                deleted = cursor.rowcount
+            connection.commit()
+        return deleted
 
 
 def build_shipment_repository(database_url: str | None) -> ShipmentRepository:

--- a/nzeroesg-api/scripts/run_retrieval_evaluation.py
+++ b/nzeroesg-api/scripts/run_retrieval_evaluation.py
@@ -10,12 +10,14 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from config import settings
+from domain.artifacts.models import ArtifactKind, ArtifactSourceType, create_artifact
 from domain.evidence.embeddings import EmbeddingAdapter, build_embedding_adapter, chunk_embeddings
 from domain.evidence.evaluation import RetrievalEvaluationCase, RetrievalEvaluationResult
 from domain.evidence.ingestion import extract_evidence
 from domain.evidence.models import EvidenceMatch, SupplierMetadata
 from domain.evidence.retrieval import RetrievalMode, reciprocal_rank_fusion
 from domain.workspaces.sessions import SessionSigner
+from persistence.artifacts import PostgresArtifactRepository
 from persistence.evidence import PostgresEvidenceRepository
 from persistence.workspaces import build_workspace_repository
 
@@ -140,6 +142,7 @@ def capture_results(
     adapter = _embedding_adapter(mode)
     workspace_repository = build_workspace_repository(database_url)
     evidence_repository = PostgresEvidenceRepository(database_url)
+    artifact_repository = PostgresArtifactRepository(database_url)
     signer = SessionSigner(
         "carbonsage-retrieval-evaluation-only-secret",
         ttl_seconds=3_600,
@@ -156,8 +159,18 @@ def capture_results(
                 filename=record.filename,
                 content_type="text/plain",
             ).document
+            artifact = create_artifact(
+                workspace_id=workspace.workspace_id,
+                kind=ArtifactKind.EVIDENCE_DOCUMENT,
+                title=document.filename,
+                source_type=ArtifactSourceType.LOCAL_UPLOAD,
+                created_by="retrieval-evaluation",
+                content_sha256=document.sha256,
+            )
+            artifact_repository.create(artifact)
             evidence_repository.store(
                 workspace.workspace_id,
+                artifact.artifact_id,
                 SupplierMetadata(
                     name=record.supplier_name,
                     region=record.region,

--- a/nzeroesg-api/tests/test_api.py
+++ b/nzeroesg-api/tests/test_api.py
@@ -91,6 +91,7 @@ def test_cors_allows_frontend_workspace_logout():
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:3000"
     assert "DELETE" in response.headers["access-control-allow-methods"]
+    assert "PATCH" in response.headers["access-control-allow-methods"]
 
 
 def test_disabled_assistant_has_an_explicit_response():

--- a/nzeroesg-api/tests/test_artifacts.py
+++ b/nzeroesg-api/tests/test_artifacts.py
@@ -1,0 +1,138 @@
+from fastapi.testclient import TestClient
+
+from domain.workspaces.principals import AuthenticationMethod, WorkspacePrincipal
+from domain.workspaces.sessions import WorkspaceSession
+from main import app
+
+SHIPMENT_CSV = (
+    b"shipment_id,origin,destination,weight_value,weight_unit,distance_value,"
+    b"distance_unit,transport_method\n"
+    b"SHP-001,Calgary,Vancouver,1000,kg,970,km,truck\n"
+)
+
+
+def authenticated_client() -> TestClient:
+    client = TestClient(app)
+    assert client.post("/demo/session").status_code == 201
+    return client
+
+
+def upload_shipments(client: TestClient):
+    return client.post(
+        "/shipments/upload",
+        files={"file": ("shipments.csv", SHIPMENT_CSV, "text/csv")},
+    )
+
+
+def test_demo_session_resolves_to_the_common_workspace_principal():
+    session = WorkspaceSession.create(workspace_id="demo-principal", issued_at=100, ttl_seconds=60)
+
+    principal = WorkspacePrincipal.from_demo_session(session)
+
+    assert principal.workspace_id == "demo-principal"
+    assert principal.subject == "demo:demo-principal"
+    assert principal.authentication_method is AuthenticationMethod.DEMO_SESSION
+    assert principal.allows("artifacts:read")
+    assert not principal.allows("embed-clients:write")
+
+
+def test_shipment_artifact_crud_is_workspace_scoped_and_deletion_hides_data():
+    owner = authenticated_client()
+    other = authenticated_client()
+
+    upload = upload_shipments(owner)
+    assert upload.status_code == 200
+    artifact = upload.json()["artifact"]
+    artifact_id = artifact["artifact_id"]
+    assert artifact["kind"] == "shipment_dataset"
+    assert artifact["status"] == "ready"
+    assert artifact["source_type"] == "local_upload"
+    assert artifact["metadata"]["accepted_rows"] == 1
+
+    listed = owner.get("/artifacts")
+    assert listed.status_code == 200
+    assert [item["artifact_id"] for item in listed.json()["artifacts"]] == [artifact_id]
+    assert other.get(f"/artifacts/{artifact_id}").status_code == 404
+    assert other.patch(f"/artifacts/{artifact_id}", json={"title": "Leaked"}).status_code == 404
+    assert other.delete(f"/artifacts/{artifact_id}").status_code == 404
+
+    renamed = owner.patch(
+        f"/artifacts/{artifact_id}",
+        json={"title": "  Q3   freight baseline  "},
+    )
+    assert renamed.status_code == 200
+    assert renamed.json()["title"] == "Q3 freight baseline"
+
+    deleted = owner.delete(f"/artifacts/{artifact_id}")
+    assert deleted.status_code == 204
+    assert owner.get(f"/artifacts/{artifact_id}").status_code == 404
+    assert owner.get("/artifacts").json()["artifacts"] == []
+    assert owner.get("/shipments").json()["accepted_rows"] == 0
+
+
+def test_evidence_artifact_identity_flows_to_citations_and_delete_hides_evidence():
+    client = authenticated_client()
+    upload = client.post(
+        "/evidence/upload",
+        data={"supplier_name": "Supplier ABC", "supplier_region": "Canada"},
+        files={
+            "file": (
+                "supplier.txt",
+                b"Supplier ABC maintains ISO 14001 certification and prioritizes rail freight.",
+                "text/plain",
+            )
+        },
+    )
+    assert upload.status_code == 200
+    artifact_id = upload.json()["artifact"]["artifact_id"]
+
+    search = client.get("/evidence/search", params={"query": "ISO 14001"})
+    assert search.status_code == 200
+    assert search.json()["matches"][0]["citation"]["artifact_id"] == artifact_id
+
+    duplicate = client.post(
+        "/evidence/upload",
+        data={"supplier_name": "Supplier ABC"},
+        files={
+            "file": (
+                "supplier-copy.txt",
+                b"Supplier ABC maintains ISO 14001 certification and prioritizes rail freight.",
+                "text/plain",
+            )
+        },
+    )
+    assert duplicate.status_code == 409
+
+    assert client.delete(f"/artifacts/{artifact_id}").status_code == 204
+    assert client.get("/suppliers").json()["suppliers"] == []
+    assert client.get("/evidence/search", params={"query": "ISO 14001"}).json()["matches"] == []
+
+
+def test_report_snapshot_is_typed_recoverable_and_soft_deletable():
+    client = authenticated_client()
+    assert upload_shipments(client).status_code == 200
+
+    created = client.post(
+        "/reports/snapshots",
+        json={"title": "Rail decision", "alternative_mode": "train"},
+    )
+    assert created.status_code == 201
+    payload = created.json()
+    artifact_id = payload["artifact"]["artifact_id"]
+    assert payload["artifact"]["kind"] == "report_snapshot"
+    assert payload["schema_version"] == "1.0"
+    assert payload["report"]["scenario"]["alternative_mode"] == "train"
+
+    recovered = client.get(f"/reports/snapshots/{artifact_id}")
+    assert recovered.status_code == 200
+    assert recovered.json()["report"] == payload["report"]
+
+    assert client.delete(f"/artifacts/{artifact_id}").status_code == 204
+    assert client.get(f"/reports/snapshots/{artifact_id}").status_code == 404
+
+
+def test_report_snapshot_requires_an_active_shipment_dataset():
+    response = authenticated_client().post("/reports/snapshots", json={})
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "A report snapshot requires an active shipment dataset."

--- a/nzeroesg-api/tests/test_pgvector_repository.py
+++ b/nzeroesg-api/tests/test_pgvector_repository.py
@@ -4,6 +4,7 @@ from hashlib import sha256
 
 import pytest
 
+from domain.artifacts.models import ArtifactKind, ArtifactSourceType, create_artifact
 from domain.evidence.embeddings import (
     EMBEDDING_DIMENSIONS,
     ChunkEmbedding,
@@ -13,6 +14,7 @@ from domain.evidence.ingestion import extract_evidence
 from domain.evidence.models import SupplierMetadata
 from domain.evidence.retrieval import RetrievalMode
 from domain.workspaces.sessions import SessionSigner
+from persistence.artifacts import PostgresArtifactRepository
 from persistence.evidence import PostgresEvidenceRepository
 from persistence.workspaces import build_workspace_repository
 from scripts.run_retrieval_evaluation import (
@@ -36,6 +38,7 @@ def unit_vector(index: int) -> tuple[float, ...]:
 def test_pgvector_storage_query_and_workspace_isolation():
     workspace_repository = build_workspace_repository(DATABASE_URL)
     evidence_repository = PostgresEvidenceRepository(DATABASE_URL or "")
+    artifact_repository = PostgresArtifactRepository(DATABASE_URL or "")
     signer = SessionSigner("test-secret-that-is-at-least-32-characters", ttl_seconds=3_600)
     first_workspace, _ = signer.issue(now=int(time.time()))
     second_workspace, _ = signer.issue(now=int(time.time()))
@@ -55,8 +58,36 @@ def test_pgvector_storage_query_and_workspace_isolation():
     ).document
 
     try:
-        evidence_repository.store(first_workspace.workspace_id, supplier, first_document)
-        evidence_repository.store(second_workspace.workspace_id, supplier, second_document)
+        first_artifact = create_artifact(
+            workspace_id=first_workspace.workspace_id,
+            kind=ArtifactKind.EVIDENCE_DOCUMENT,
+            title=first_document.filename,
+            source_type=ArtifactSourceType.LOCAL_UPLOAD,
+            created_by="test",
+            content_sha256=first_document.sha256,
+        )
+        second_artifact = create_artifact(
+            workspace_id=second_workspace.workspace_id,
+            kind=ArtifactKind.EVIDENCE_DOCUMENT,
+            title=second_document.filename,
+            source_type=ArtifactSourceType.LOCAL_UPLOAD,
+            created_by="test",
+            content_sha256=second_document.sha256,
+        )
+        artifact_repository.create(first_artifact)
+        artifact_repository.create(second_artifact)
+        evidence_repository.store(
+            first_workspace.workspace_id,
+            first_artifact.artifact_id,
+            supplier,
+            first_document,
+        )
+        evidence_repository.store(
+            second_workspace.workspace_id,
+            second_artifact.artifact_id,
+            supplier,
+            second_document,
+        )
         pending = evidence_repository.list_unembedded_documents(
             first_workspace.workspace_id,
             spec,

--- a/nzeroesg-api/tests/test_retrieval.py
+++ b/nzeroesg-api/tests/test_retrieval.py
@@ -59,8 +59,8 @@ def test_in_memory_semantic_search_is_workspace_and_model_scoped():
     ).document
     supplier = SupplierMetadata("Supplier ABC", "Canada", (), ("train",))
 
-    repository.store("workspace-a", supplier, first_document)
-    repository.store("workspace-b", supplier, second_document)
+    repository.store("workspace-a", "artifact-a", supplier, first_document)
+    repository.store("workspace-b", "artifact-b", supplier, second_document)
     pending = repository.list_unembedded_documents("workspace-a", spec)
 
     assert [document.document_sha256 for document in pending] == [first_document.sha256]
@@ -111,6 +111,7 @@ def test_in_memory_semantic_search_is_workspace_and_model_scoped():
 
 def test_reciprocal_rank_fusion_preserves_citations_and_both_rank_signals():
     first = EvidenceMatch(
+        artifact_id="artifact-a",
         supplier_name="Supplier ABC",
         filename="first.txt",
         excerpt="Rail commitment",

--- a/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
+++ b/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getBackendUrl } from "@/app/api/urls";
+
+export type ArtifactKind =
+  | "shipment_dataset"
+  | "evidence_document"
+  | "report_snapshot";
+
+type Artifact = {
+  artifact_id: string;
+  workspace_id: string;
+  kind: ArtifactKind;
+  title: string;
+  status: "processing" | "ready" | "failed";
+  source_type:
+    | "local_upload"
+    | "generated"
+    | "google_drive"
+    | "legacy_migration";
+  source_reference: string | null;
+  media_type: string | null;
+  content_sha256: string | null;
+  version: number;
+  metadata: Record<string, unknown>;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+const kindLabels: Record<ArtifactKind, string> = {
+  shipment_dataset: "Shipment dataset",
+  evidence_document: "Evidence document",
+  report_snapshot: "Report snapshot",
+};
+
+const sourceLabels: Record<Artifact["source_type"], string> = {
+  local_upload: "Local upload",
+  generated: "Generated",
+  google_drive: "Google Drive",
+  legacy_migration: "Migrated record",
+};
+
+type ArtifactCatalogProps = {
+  refreshToken: number;
+  onDeleted: (kind: ArtifactKind) => void | Promise<void>;
+};
+
+export default function ArtifactCatalog({
+  refreshToken,
+  onDeleted,
+}: ArtifactCatalogProps) {
+  const [artifacts, setArtifacts] = useState<Artifact[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draftTitle, setDraftTitle] = useState("");
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isCurrent = true;
+    fetch(`${getBackendUrl()}/artifacts`, { credentials: "include" })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("Workspace artifacts could not be loaded.");
+        }
+        return (await response.json()) as { artifacts: Artifact[] };
+      })
+      .then((payload) => {
+        if (isCurrent) {
+          setArtifacts(payload.artifacts);
+        }
+      })
+      .catch((requestError) => {
+        if (isCurrent) {
+          setError(
+            requestError instanceof Error
+              ? requestError.message
+              : "Workspace artifacts could not be loaded.",
+          );
+        }
+      });
+    return () => {
+      isCurrent = false;
+    };
+  }, [refreshToken]);
+
+  async function renameArtifact(artifact: Artifact) {
+    const title = draftTitle.trim();
+    if (!title) {
+      setError("Artifact title cannot be empty.");
+      return;
+    }
+    setBusyId(artifact.artifact_id);
+    setError(null);
+    try {
+      const response = await fetch(
+        `${getBackendUrl()}/artifacts/${artifact.artifact_id}`,
+        {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error("Artifact could not be renamed.");
+      }
+      const updated = (await response.json()) as Artifact;
+      setArtifacts((current) =>
+        current.map((item) =>
+          item.artifact_id === updated.artifact_id ? updated : item,
+        ),
+      );
+      setEditingId(null);
+      setStatusMessage(`Renamed artifact to ${updated.title}.`);
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "Artifact could not be renamed.",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function deleteArtifact(artifact: Artifact) {
+    const confirmed = window.confirm(
+      `Delete “${artifact.title}”? Its active derived data will no longer be available.`,
+    );
+    if (!confirmed) {
+      return;
+    }
+    setBusyId(artifact.artifact_id);
+    setError(null);
+    try {
+      const response = await fetch(
+        `${getBackendUrl()}/artifacts/${artifact.artifact_id}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (!response.ok) {
+        throw new Error("Artifact could not be deleted.");
+      }
+      setArtifacts((current) =>
+        current.filter((item) => item.artifact_id !== artifact.artifact_id),
+      );
+      setStatusMessage(`Deleted ${artifact.title}.`);
+      await onDeleted(artifact.kind);
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "Artifact could not be deleted.",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <section
+      id="artifacts"
+      className="mt-8 rounded-xl border border-border bg-muted p-6"
+    >
+      <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-accent">
+        Phase 7 control plane
+      </p>
+      <h2 className="text-2xl font-semibold text-primary">
+        Workspace artifacts
+      </h2>
+      <p className="mt-2 max-w-3xl leading-7 text-muted-foreground">
+        Track the source, status, and provenance of uploaded datasets, supplier
+        evidence, and saved decision reports. Raw files are not retained beyond
+        bounded ingestion.
+      </p>
+
+      {error ? (
+        <p className="mt-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
+          {error}
+        </p>
+      ) : null}
+      <p className="sr-only" role="status" aria-live="polite">
+        {statusMessage}
+      </p>
+
+      {artifacts.length === 0 ? (
+        <p className="mt-5 rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
+          No active artifacts yet. Upload shipment data or supplier evidence to
+          create the first workspace artifact.
+        </p>
+      ) : (
+        <div className="mt-5 grid gap-4 xl:grid-cols-2">
+          {artifacts.map((artifact) => (
+            <article
+              key={artifact.artifact_id}
+              className="min-w-0 rounded-lg border border-border bg-background p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-accent">
+                    {kindLabels[artifact.kind]}
+                  </p>
+                  <h3 className="mt-1 break-words font-semibold text-primary">
+                    {artifact.title}
+                  </h3>
+                </div>
+                <span className="rounded-full bg-secondary/10 px-2 py-1 text-xs font-semibold capitalize text-primary">
+                  {artifact.status}
+                </span>
+              </div>
+
+              <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
+                <div>
+                  <dt className="text-xs text-muted-foreground">Source</dt>
+                  <dd className="break-words text-primary">
+                    {sourceLabels[artifact.source_type]}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">Created</dt>
+                  <dd className="text-primary">
+                    {new Intl.DateTimeFormat(undefined, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    }).format(new Date(artifact.created_at))}
+                  </dd>
+                </div>
+              </dl>
+
+              <details className="mt-4 text-sm text-muted-foreground">
+                <summary className="cursor-pointer font-semibold text-primary">
+                  Inspect provenance
+                </summary>
+                <dl className="mt-3 space-y-2">
+                  <div>
+                    <dt className="text-xs">Artifact ID</dt>
+                    <dd className="break-all font-mono text-xs">
+                      {artifact.artifact_id}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs">Source reference</dt>
+                    <dd className="break-words">
+                      {artifact.source_reference ?? "Generated in workspace"}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs">Content identity</dt>
+                    <dd className="break-all font-mono text-xs">
+                      {artifact.content_sha256 ?? "No source hash"}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs">Version</dt>
+                    <dd>{artifact.version}</dd>
+                  </div>
+                </dl>
+              </details>
+
+              {editingId === artifact.artifact_id ? (
+                <div className="mt-4 flex flex-wrap items-end gap-2">
+                  <label className="flex min-w-0 flex-1 flex-col gap-1 text-sm font-semibold text-primary">
+                    Artifact title
+                    <input
+                      value={draftTitle}
+                      onChange={(event) => setDraftTitle(event.target.value)}
+                      maxLength={255}
+                      className="min-w-0 rounded-lg border border-border bg-muted px-3 py-2 font-normal"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => renameArtifact(artifact)}
+                    disabled={busyId === artifact.artifact_id}
+                    className="rounded-full bg-secondary px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                  >
+                    Save name
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditingId(null)}
+                    className="rounded-full border border-border px-4 py-2 text-sm font-semibold text-primary"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingId(artifact.artifact_id);
+                      setDraftTitle(artifact.title);
+                      setError(null);
+                    }}
+                    className="rounded-full border border-secondary px-4 py-2 text-sm font-semibold text-secondary"
+                  >
+                    Rename {artifact.title}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => deleteArtifact(artifact)}
+                    disabled={busyId === artifact.artifact_id}
+                    className="rounded-full border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 disabled:opacity-60"
+                  >
+                    Delete {artifact.title}
+                  </button>
+                </div>
+              )}
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/nzeroesg-client/app/dashboard/page.tsx
+++ b/nzeroesg-client/app/dashboard/page.tsx
@@ -5,6 +5,9 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 
 import { getBackendUrl } from "@/app/api/urls";
+import ArtifactCatalog, {
+  type ArtifactKind,
+} from "@/app/dashboard/ArtifactCatalog";
 
 type Quota = { used: number; limit: number };
 
@@ -77,6 +80,7 @@ type EvidenceMatch = {
   filename: string;
   excerpt: string;
   citation: {
+    artifact_id: string;
     page_number: number | null;
     chunk_index: number;
     document_sha256: string;
@@ -126,6 +130,7 @@ type ScenarioData = {
 
 const navigation = [
   { label: "Overview", status: "Ready", href: "#overview" },
+  { label: "Artifacts", status: "Ready", href: "#artifacts" },
   { label: "Shipments", status: "Ready", href: "#shipments" },
   { label: "Suppliers / Evidence", status: "Ready", href: "#evidence" },
   { label: "Scenarios", status: "Ready", href: "#scenarios" },
@@ -166,6 +171,9 @@ export default function UserPortalPage() {
   const [scenarioError, setScenarioError] = useState<string | null>(null);
   const [isRunningScenario, setIsRunningScenario] = useState(false);
   const [isExportingReport, setIsExportingReport] = useState(false);
+  const [isSavingSnapshot, setIsSavingSnapshot] = useState(false);
+  const [artifactRefreshToken, setArtifactRefreshToken] = useState(0);
+  const [artifactStatus, setArtifactStatus] = useState<string | null>(null);
 
   useEffect(() => {
     let isCurrent = true;
@@ -276,6 +284,7 @@ export default function UserPortalPage() {
         );
       }
       setShipmentData((await response.json()) as ShipmentData);
+      setArtifactRefreshToken((current) => current + 1);
       setSelectedFile(null);
       const workspaceResponse = await fetch(`${getBackendUrl()}/demo/session`, {
         credentials: "include",
@@ -334,6 +343,7 @@ export default function UserPortalPage() {
         };
         setSuppliers(payload.suppliers);
       }
+      setArtifactRefreshToken((current) => current + 1);
       setEvidenceFile(null);
       setSupplierName("");
       setEvidenceError(null);
@@ -460,6 +470,73 @@ export default function UserPortalPage() {
     } finally {
       setIsExportingReport(false);
     }
+  }
+
+  async function saveReportSnapshot() {
+    setIsSavingSnapshot(true);
+    setScenarioError(null);
+    setArtifactStatus(null);
+    try {
+      const response = await fetch(`${getBackendUrl()}/reports/snapshots`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          alternative_mode: scenarioData?.alternative_mode ?? null,
+        }),
+      });
+      if (!response.ok) {
+        const detail = (await response.json().catch(() => null)) as {
+          detail?: string;
+        } | null;
+        throw new Error(
+          detail?.detail ?? "Report snapshot could not be saved.",
+        );
+      }
+      const payload = (await response.json()) as {
+        artifact: { title: string };
+      };
+      setArtifactRefreshToken((current) => current + 1);
+      setArtifactStatus(`Saved ${payload.artifact.title}.`);
+    } catch (requestError) {
+      setScenarioError(
+        requestError instanceof Error
+          ? requestError.message
+          : "Report snapshot could not be saved.",
+      );
+    } finally {
+      setIsSavingSnapshot(false);
+    }
+  }
+
+  async function handleArtifactDeleted(kind: ArtifactKind) {
+    setArtifactRefreshToken((current) => current + 1);
+    if (kind === "shipment_dataset") {
+      setShipmentData(null);
+      setScenarioData(null);
+      setArtifactStatus(
+        "The shipment dataset and its active analysis were removed.",
+      );
+      return;
+    }
+    if (kind === "evidence_document") {
+      setEvidenceMatches([]);
+      setEvidenceSearchData(null);
+      const response = await fetch(`${getBackendUrl()}/suppliers`, {
+        credentials: "include",
+      });
+      if (response.ok) {
+        const payload = (await response.json()) as {
+          suppliers: SupplierCard[];
+        };
+        setSuppliers(payload.suppliers);
+      }
+      setArtifactStatus(
+        "The evidence artifact was removed from active retrieval.",
+      );
+      return;
+    }
+    setArtifactStatus("The saved report snapshot was removed.");
   }
 
   async function leaveWorkspace() {
@@ -611,6 +688,15 @@ export default function UserPortalPage() {
             id.
           </p>
         </div>
+
+        <ArtifactCatalog
+          refreshToken={artifactRefreshToken}
+          onDeleted={handleArtifactDeleted}
+        />
+
+        <p className="sr-only" role="status" aria-live="polite">
+          {artifactStatus}
+        </p>
 
         <section
           id="shipments"
@@ -1162,7 +1248,23 @@ export default function UserPortalPage() {
             >
               {isExportingReport ? "Exporting…" : "Export CSV report"}
             </button>
+            <button
+              type="button"
+              onClick={saveReportSnapshot}
+              disabled={
+                isSavingSnapshot || !shipmentData?.analysis.shipment_count
+              }
+              className="rounded-full border border-secondary px-5 py-3 font-semibold text-secondary transition hover:bg-secondary hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSavingSnapshot ? "Saving…" : "Save report snapshot"}
+            </button>
           </form>
+
+          {artifactStatus ? (
+            <p className="mt-4 rounded-lg border border-border bg-background px-4 py-3 text-sm text-primary">
+              {artifactStatus}
+            </p>
+          ) : null}
 
           {scenarioError ? (
             <p className="mt-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">

--- a/nzeroesg-client/e2e/demo.spec.ts
+++ b/nzeroesg-client/e2e/demo.spec.ts
@@ -37,6 +37,16 @@ test("completes the five-minute demo workflow and exports a report", async ({
   ).toBeVisible();
   await expect(page.getByText("Emissions by mode")).toBeVisible();
   await expect(page.getByText("Top shipment hotspots")).toBeVisible();
+  await expect(
+    page.getByText("Shipment dataset", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Rename shipments.csv" }).click();
+  await page.getByLabel("Artifact title").fill("Q3 freight baseline");
+  await page.getByRole("button", { name: "Save name" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Q3 freight baseline" }),
+  ).toBeVisible();
 
   await page.getByLabel("Supplier name").fill("Supplier ABC");
   await page
@@ -79,6 +89,14 @@ test("completes the five-minute demo workflow and exports a report", async ({
     page.getByRole("table", { name: "Scenario result by shipment" }),
   ).toBeVisible();
 
+  await page.getByRole("button", { name: "Save report snapshot" }).click();
+  await expect(
+    page.locator("#scenarios").getByText(/Saved Decision report/),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Report snapshot", { exact: true }),
+  ).toBeVisible();
+
   const downloadPromise = page.waitForEvent("download");
   await page.getByRole("button", { name: "Export CSV report" }).click();
   const download = await downloadPromise;
@@ -113,7 +131,39 @@ test("keeps two demo workspaces isolated", async ({ page, browser }) => {
       "No supplier evidence has been uploaded in this workspace.",
     ),
   ).toBeVisible();
+  await expect(
+    secondPage.getByText(
+      "No active artifacts yet. Upload shipment data or supplier evidence to create the first workspace artifact.",
+    ),
+  ).toBeVisible();
   await secondContext.close();
+});
+
+test("soft-deletes a shipment artifact and removes its active analysis", async ({
+  page,
+}) => {
+  await enterWorkspace(page);
+  await page.getByLabel("Shipment CSV").setInputFiles({
+    name: "shipments.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(shipmentCsv),
+  });
+  await page.getByRole("button", { name: "Upload and analyze" }).click();
+  const deleteButton = page.getByRole("button", {
+    name: "Delete shipments.csv",
+  });
+  await expect(deleteButton).toBeVisible();
+  page.once("dialog", (dialog) => dialog.accept());
+  await deleteButton.click();
+
+  await expect(
+    page.getByText(
+      "No active artifacts yet. Upload shipment data or supplier evidence to create the first workspace artifact.",
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Run scenario" }),
+  ).toBeDisabled();
 });
 
 test("supports keyboard entry and a narrow viewport", async ({ page }) => {

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,9 @@ evidence-grounded CarbonSage agent described in the roadmap.
   quality, which is evaluated in the next agent phase.
 - Scenario comparisons, accessible chart alternatives, printable report
   previews, and authenticated CSV export.
+- A workspace artifact catalog for shipment datasets, evidence documents, and
+  report snapshots, with provenance, citation identity, rename, bounded
+  soft-deletion, and cross-workspace isolation.
 - A Vercel client, Render API, Neon PostgreSQL database, and credential-free CI
   and browser checks.
 
@@ -78,16 +81,15 @@ evidence-grounded CarbonSage agent described in the roadmap.
 
 CarbonSage will build on that baseline in a controlled order:
 
-1. A small workspace artifact catalog with CRUD and provenance.
-2. Typed, workspace-scoped tools for evidence search, emissions calculations,
+1. Typed, workspace-scoped tools for evidence search, emissions calculations,
    scenario comparison, and reports.
-3. A versioned response protocol for text, metrics, tables, charts, citations,
+2. A versioned response protocol for text, metrics, tables, charts, citations,
    warnings, artifact references, and confirmed actions.
-4. A dashboard agent playground using the same runtime and renderer as the
+3. A dashboard agent playground using the same runtime and renderer as the
    embedded experience.
-5. A framework-independent JavaScript loader and authenticated iframe.
-6. One explicit, read-only Google Drive selected-file import.
-7. Optionally, a read-only MCP adapter over the same stable application tools.
+4. A framework-independent JavaScript loader and authenticated iframe.
+5. One explicit, read-only Google Drive selected-file import.
+6. Optionally, a read-only MCP adapter over the same stable application tools.
 
 Dropbox, billing, organization administration, background synchronization,
 enterprise RBAC, and a family of framework-specific SDKs are intentionally
@@ -123,15 +125,15 @@ The detailed decisions and delivery gates live in:
 
 ## Stack
 
-| Part | Role |
-| --- | --- |
-| Next.js and React | Public site, control plane, agent playground, embed UI, and structured renderers |
-| FastAPI | Sessions, artifacts, retrieval, typed tools, conversations, and reports |
-| Neon PostgreSQL | Workspace data, evidence, full-text search, and evaluated vector retrieval |
-| LangChain | Optional orchestration adapter, not domain logic or source of truth |
-| Vercel | Public client deployment from `main` |
-| Render | FastAPI deployment from the production `main` branch |
-| Docker and GitHub Actions | Reproducible local setup and automated checks |
+| Part                      | Role                                                                             |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| Next.js and React         | Public site, control plane, agent playground, embed UI, and structured renderers |
+| FastAPI                   | Sessions, artifacts, retrieval, typed tools, conversations, and reports          |
+| Neon PostgreSQL           | Workspace data, evidence, full-text search, and evaluated vector retrieval       |
+| LangChain                 | Optional orchestration adapter, not domain logic or source of truth              |
+| Vercel                    | Public client deployment from `main`                                             |
+| Render                    | FastAPI deployment from the production `main` branch                             |
+| Docker and GitHub Actions | Reproducible local setup and automated checks                                    |
 
 ## Run locally
 


### PR DESCRIPTION
## Summary
- add workspace artifact and principal contracts with migration 005
- link shipments, evidence, citations, and typed report snapshots to artifacts
- add workspace-scoped list/detail/rename/soft-delete APIs
- add the bounded dashboard artifact catalog and confirmed lifecycle actions
- preserve provider-disabled and deterministic workflows

## Local verification
- backend: 79 passed, 2 PostgreSQL-only skipped without DATABASE_URL
- PostgreSQL/pgvector: 81 passed
- frontend typecheck, lint, formatting, and production build passed
- Playwright: 4 passed against disposable PostgreSQL
- secret scan clean
- production dependency audit: 0 vulnerabilities

## Scope boundary
Agent runtime, embed authentication, Google Drive, and MCP remain deferred to later phases.