### PR TITLE
test: tolerate production service latency

### DIFF
--- a/nzeroesg-client/e2e/demo.spec.ts
+++ b/nzeroesg-client/e2e/demo.spec.ts
@@ -9,6 +9,11 @@ const shipmentCsv = [
 const supplierEvidence =
   "Supplier ABC holds ISO 14001 certification and operates rail routes in Canada.";
 
+// Render, Neon, and the configured embedding provider can need a few seconds
+// to wake up in the production smoke test. Keep action-result assertions
+// bounded without treating a normal remote round trip as a UI failure.
+const backendActionTimeout = 30_000;
+
 async function enterWorkspace(page: Page) {
   await page.goto("/login");
   await expect(
@@ -22,6 +27,7 @@ async function enterWorkspace(page: Page) {
 test("completes the five-minute demo workflow and exports a report", async ({
   page,
 }) => {
+  test.setTimeout(120_000);
   await enterWorkspace(page);
 
   await page.getByLabel("Shipment CSV").setInputFiles({
@@ -30,16 +36,18 @@ test("completes the five-minute demo workflow and exports a report", async ({
     buffer: Buffer.from(shipmentCsv),
   });
   await page.getByRole("button", { name: "Upload and analyze" }).click();
-  await expect(page.getByText("Accepted shipments")).toBeVisible();
+  await expect(page.getByText("Accepted shipments")).toBeVisible({
+    timeout: backendActionTimeout,
+  });
   await expect(page.getByText("Total emissions")).toBeVisible();
   await expect(
     page.getByRole("table").last().getByRole("cell", { name: "S-001" }),
   ).toBeVisible();
   await expect(page.getByText("Emissions by mode")).toBeVisible();
   await expect(page.getByText("Top shipment hotspots")).toBeVisible();
-  await expect(
-    page.getByText("Shipment dataset", { exact: true }),
-  ).toBeVisible();
+  await expect(page.getByText("Shipment dataset", { exact: true })).toBeVisible(
+    { timeout: backendActionTimeout },
+  );
 
   await page.getByRole("button", { name: "Rename shipments.csv" }).click();
   await page.getByLabel("Artifact title").fill("Q3 freight baseline");
@@ -57,11 +65,15 @@ test("completes the five-minute demo workflow and exports a report", async ({
       buffer: Buffer.from(supplierEvidence),
     });
   await page.getByRole("button", { name: "Upload evidence" }).click();
-  await expect(page.getByText("Supplier ABC", { exact: true })).toBeVisible();
+  await expect(page.getByText("Supplier ABC", { exact: true })).toBeVisible({
+    timeout: backendActionTimeout,
+  });
 
   await page.getByLabel("Search document evidence").fill("ISO 14001");
   await page.getByRole("button", { name: "Search citations" }).click();
-  await expect(page.getByText(/Supplier ABC holds ISO 14001/)).toBeVisible();
+  await expect(page.getByText(/Supplier ABC holds ISO 14001/)).toBeVisible({
+    timeout: backendActionTimeout,
+  });
   await expect(page.getByText(/Citation: supplier.txt/)).toBeVisible();
 
   await page.getByLabel("Retrieval mode").selectOption("hybrid");
@@ -69,7 +81,7 @@ test("completes the five-minute demo workflow and exports a report", async ({
   const retrievalStatus = page.getByText(
     /Used (hybrid|lexical) retrieval · semantic provider (available|unavailable)/,
   );
-  await expect(retrievalStatus).toBeVisible();
+  await expect(retrievalStatus).toBeVisible({ timeout: backendActionTimeout });
   const retrievalStatusText = await retrievalStatus.textContent();
   if (retrievalStatusText?.includes("provider unavailable")) {
     expect(retrievalStatusText).toContain(
@@ -82,7 +94,9 @@ test("completes the five-minute demo workflow and exports a report", async ({
   }
 
   await page.getByRole("button", { name: "Run scenario" }).click();
-  await expect(page.getByText("Current baseline")).toBeVisible();
+  await expect(page.getByText("Current baseline")).toBeVisible({
+    timeout: backendActionTimeout,
+  });
   await expect(page.getByText("Scenario comparison")).toBeVisible();
   await expect(page.getByText("Report preview · methodology")).toBeVisible();
   await expect(
@@ -92,7 +106,7 @@ test("completes the five-minute demo workflow and exports a report", async ({
   await page.getByRole("button", { name: "Save report snapshot" }).click();
   await expect(
     page.locator("#scenarios").getByText(/Saved Decision report/),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: backendActionTimeout });
   await expect(
     page.getByText("Report snapshot", { exact: true }),
   ).toBeVisible();
@@ -149,10 +163,13 @@ test("soft-deletes a shipment artifact and removes its active analysis", async (
     buffer: Buffer.from(shipmentCsv),
   });
   await page.getByRole("button", { name: "Upload and analyze" }).click();
+  await expect(page.getByText("Accepted shipments")).toBeVisible({
+    timeout: backendActionTimeout,
+  });
   const deleteButton = page.getByRole("button", {
     name: "Delete shipments.csv",
   });
-  await expect(deleteButton).toBeVisible();
+  await expect(deleteButton).toBeVisible({ timeout: backendActionTimeout });
   page.once("dialog", (dialog) => dialog.accept());
   await deleteButton.click();
 
@@ -160,7 +177,7 @@ test("soft-deletes a shipment artifact and removes its active analysis", async (
     page.getByText(
       "No active artifacts yet. Upload shipment data or supplier evidence to create the first workspace artifact.",
     ),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: backendActionTimeout });
   await expect(
     page.getByRole("button", { name: "Run scenario" }),
   ).toBeDisabled();


### PR DESCRIPTION
## Summary
- synchronize browser checks on completed backend outcomes
- allow bounded Render, Neon, and embedding-provider latency
- give the complete multi-step workflow an explicit total runtime budget

## Verification
- npm run format:check
- npm run lint
- npm run typecheck
- local PostgreSQL/pgvector Playwright: 4 passed
- live Vercel + Render/Neon Playwright: 4 passed