### PR TITLE
Add bounded S3 artifact source storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       APP_ENV: development
       ASSISTANT_ENABLED: "false"
+      ARTIFACT_STORAGE_ENABLED: "false"
       DATABASE_URL: postgresql://nzeroesg@database:5432/nzeroesg
       CORS_ORIGINS: http://localhost:3000
     depends_on:

--- a/docs/app.architecture.md
+++ b/docs/app.architecture.md
@@ -49,6 +49,9 @@ Neon PostgreSQL
 ├── documents, chunks, and citations
 ├── lexical and evaluated vector indexes
 └── conversations and validated response envelopes
+                 │
+                 └── AWS S3 Standard / Canada Central
+                     └── private validated source bytes, maximum 24 hours
 ```
 
 No Redis, MongoDB, GraphQL gateway, message broker, dedicated vector database,
@@ -121,9 +124,16 @@ scenario results remain normalized domain records linked to their source
 artifact. Suppliers remain first-class domain entities rather than untyped
 artifact metadata.
 
-Raw uploaded files remain temporary unless a measured requirement changes the
-retention policy. The artifact catalog retains provenance and normalized
-results, not an unbounded file store.
+Validated shipment and evidence source uploads are retained in private AWS S3
+for the earlier of workspace expiry or 24 hours. The artifact catalog retains
+provenance and normalized results after source access expires; generated report
+snapshots remain PostgreSQL records. This is a bounded recovery and provenance
+window, not an unbounded file store.
+
+S3 access stays behind the FastAPI artifact service. PostgreSQL atomically
+reserves global bytes and monthly write/read/egress allowance before each
+billable operation, keeping the priced envelope below USD $0.50/month. The
+browser receives neither AWS credentials nor a reusable object URL.
 
 The implemented lifecycle keeps creation behind the validated shipment,
 evidence, and report services rather than exposing an arbitrary file endpoint.

--- a/docs/decisions/001-aws-s3-artifact-source-storage.md
+++ b/docs/decisions/001-aws-s3-artifact-source-storage.md
@@ -1,0 +1,250 @@
+# Decision 001: AWS S3 artifact source storage
+
+- **Status:** Accepted; implemented behind explicit runtime activation
+- **Decision date:** August 9, 2026
+- **Scope:** CarbonSage initial demo workspaces
+- **Review trigger:** Any retention beyond 24 hours, direct browser-to-S3 transfer,
+  a second AWS region, files larger than 10 MB, background processing, or a
+  projected S3 charge above USD $0.50 per month
+
+## Decision
+
+CarbonSage will retain validated shipment CSV and supplier-evidence source files
+in one private Amazon S3 Standard bucket in `ca-central-1`. Retention is bounded
+by the earlier of the workspace expiry and 24 hours. Generated report snapshots,
+normalized shipments, extracted evidence, chunks, embeddings, citations, and
+artifact catalog records remain in PostgreSQL.
+
+The FastAPI modular monolith owns every upload, download, authorization check,
+quota reservation, and delete request. The browser never receives AWS
+credentials or a reusable S3 URL. S3 is an external blob boundary, not a new
+application service or source of domain truth.
+
+This decision supersedes the earlier temporary-upload assumption. It does not
+create an indefinite document repository: retained bytes are a short-lived,
+private convenience for exact-source recovery, provenance inspection, and
+future reprocessing.
+
+## Why S3
+
+The alternatives were technically viable, but S3 gives this project the best
+balance of architecture, learning value, and future portability:
+
+- it demonstrates the canonical object-storage API, scoped IAM, lifecycle
+  management, server-side encryption, and provider-aware cost controls;
+- it is a credible deployment boundary for a future hosted product without
+  requiring MinIO operations or another application platform;
+- the source-file volume is so small that ordinary paid pricing is measurable
+  in cents rather than dollars;
+- the application contract remains provider-neutral enough to replace the
+  object-store adapter later without changing artifact or ingestion domains.
+
+Cloudflare R2 and Backblaze B2 offered stronger recurring free allowances.
+They remain reasonable future cost alternatives, but maximizing free-tier
+capacity is not the only objective. AWS experience and its mature IAM/lifecycle
+model are valuable parts of the implementation proof. MinIO on free Render was
+rejected because free Render filesystems are ephemeral and persistent disks
+require a paid service; operating a single-node object store would add more
+failure modes than value.
+
+## Exact storage boundary
+
+Stored source objects use opaque identifiers and content identity rather than
+user-controlled filenames:
+
+```text
+workspaces/{workspace_id}/artifacts/{artifact_id}/v{version}/{sha256}
+```
+
+PostgreSQL migration `006_artifact_object_storage.sql` records:
+
+- workspace and artifact identity;
+- provider, bucket alias, and object key;
+- content type, byte size, SHA-256 digest, and S3 ETag;
+- reservation, ready, delete-pending, deleted, or failed status;
+- creation, storage, expiry, and deletion timestamps;
+- global active/reserved bytes and monthly request/egress counters.
+
+The object metadata deliberately has no foreign key to an expiring workspace.
+That allows a deletion tombstone to survive PostgreSQL workspace cleanup until
+the S3 delete succeeds or the bucket lifecycle rule removes the object.
+
+Steady-state workspace storage is at most approximately 42 MB: one 10 MiB
+shipment source and three 10 MiB evidence sources. The configured 55,000,000
+byte workspace limit allows a new maximum-size shipment to be retained before
+the previous shipment is deleted, preserving a safe replacement sequence.
+
+## Cost ceiling and circuit breaker
+
+The approved S3 service ceiling is **USD $0.50 per calendar month before tax**.
+It does not include exchange-rate conversion, unrelated AWS services, or
+out-of-band bucket activity by an administrator.
+
+The application uses the August 2026 S3 Standard rates for Canada Central:
+
+| Cost dimension | Rate used by policy |
+| --- | ---: |
+| Storage | $0.025 per GB-month |
+| PUT, COPY, POST, or LIST | $0.0055 per 1,000 requests |
+| GET, HEAD, and other reads | $0.0044 per 10,000 requests |
+| Internet egress safety rate | $0.09 per GB |
+
+The egress calculation deliberately ignores AWS's recurring first 100 GB of
+account-wide internet transfer at no charge. Promotional credits and Free Tier
+storage/request allowances are also ignored. The breaker therefore remains
+conservative if those benefits change or are consumed by another workload.
+
+Hard limits are:
+
+| Dimension | Application stop | Maximum priced contribution |
+| --- | ---: | ---: |
+| Active plus reserved storage | 4,000,000,000 bytes | $0.100 |
+| Write-class requests | 10,000/month | $0.055 |
+| Read-class requests | 100,000/month | $0.044 |
+| Download egress | 2,000,000,000 bytes/month | $0.180 |
+| **Estimated maximum** |  | **$0.379** |
+
+The remaining approximately $0.121 is safety margin for small pricing changes
+and estimation error. Configured limits are validated at API startup; a limit
+set that reaches the $0.50 ceiling is rejected. The AWS SDK is configured for
+one total attempt per operation so automatic retries cannot multiply billable
+requests outside the ledger.
+
+The breaker is transactional and shared across API instances in PostgreSQL:
+
+1. Lock the global state and current calendar-month usage row.
+2. Verify workspace bytes, global bytes, and the relevant monthly operation
+   limit.
+3. Reserve bytes and permanently count the provider request before calling S3.
+4. Move reserved bytes to active bytes only after a successful PUT.
+5. Retain consumed request allowance after a provider failure because AWS may
+   still have received a billable request.
+
+When a limit is reached, the API returns `507 Insufficient Storage` before an
+S3 operation. It does not silently retain a file outside policy or depend on a
+delayed AWS billing alert. AWS Budgets should still alert at $0.25 and apply a
+defensive deny action near $0.45, but AWS documents that billing data can lag;
+those controls are defense in depth rather than the circuit breaker.
+
+## Upload, download, and failure behavior
+
+- Uploads remain bounded to 10 MB and pass existing CSV/evidence validation
+  before the source is retained.
+- A durable budget reservation is created before `PutObject`.
+- Objects use S3-managed AES-256 encryption (`SSE-S3`) and TLS. Customer-managed
+  KMS keys are intentionally excluded because they add separate request and key
+  charges without improving this demo's threat model.
+- Authenticated downloads pass through FastAPI. The API reserves one read and
+  the full object size as egress, then validates byte length and SHA-256 after
+  `GetObject`.
+- There are no public objects, browser AWS credentials, presigned URLs,
+  multipart uploads, Transfer Acceleration, replication, inventory, access
+  logging, or object version history in this slice.
+- A provider or integrity failure returns a sanitized `503`; normalized data is
+  not presented as a successfully retained upload when the configured storage
+  operation fails.
+- Artifact deletion hides the artifact and derivatives immediately. A failed
+  physical delete remains `delete_pending` and is retried by bounded cleanup;
+  the S3 lifecycle rule is the final backstop.
+- Local development and credential-free CI keep storage explicitly disabled and
+  label source retention as `ephemeral`. Tests inject an in-memory object store
+  while exercising the same service and breaker contracts.
+
+## Retention semantics
+
+Application access ends exactly at the workspace/source expiry. CarbonSage
+attempts physical deletion on artifact deletion and opportunistically sweeps
+expired/delete-pending records before new retained uploads.
+
+The bucket also expires objects after one day and aborts incomplete multipart
+uploads after one day. S3 lifecycle processing is asynchronous, so the product
+promise is:
+
+> Source access ends within 24 hours; CarbonSage requests deletion at expiry,
+> while S3 lifecycle processing provides the provider-level deletion backstop.
+
+The lifecycle configuration is infrastructure policy, not a substitute for
+application authorization or the database breaker.
+
+## AWS resources and access
+
+[`infra/aws/artifact-storage.yaml`](../../infra/aws/artifact-storage.yaml)
+defines:
+
+- one private, unversioned S3 bucket;
+- default SSE-S3 encryption;
+- complete public-access blocking and bucket-owner-enforced ownership;
+- a TLS-only bucket policy;
+- one-day expiration and incomplete-upload cleanup;
+- a managed runtime policy limited to bucket location plus
+  `PutObject`, `GetObject`, and `DeleteObject` under `workspaces/*`.
+
+The template does not create or commit an access key. Attach its runtime policy
+to a dedicated IAM principal, create credentials through AWS, and store them
+only in Render's secret environment configuration.
+
+Required production configuration:
+
+```text
+ARTIFACT_STORAGE_ENABLED=true
+AWS_S3_BUCKET=<private bucket name>
+AWS_S3_REGION=ca-central-1
+AWS_ACCESS_KEY_ID=<Render secret>
+AWS_SECRET_ACCESS_KEY=<Render secret>
+DATABASE_URL=<existing Neon URL>
+```
+
+The remaining `ARTIFACT_STORAGE_*` values should normally keep their checked-in
+defaults. Lower values are safe. Any higher combination still has to pass the
+startup calculation below $0.50 and should require review of this decision.
+
+## Operational checks before production activation
+
+1. Deploy the CloudFormation stack in `ca-central-1`.
+2. Confirm public access is blocked, versioning is suspended, default encryption
+   is AES-256, and the one-day lifecycle rule is enabled.
+3. Attach only the generated runtime policy to the dedicated API principal.
+4. Add credentials and storage environment values in Render; never add them to
+   Git, Vercel, browser code, logs, or screenshots.
+5. Configure AWS Budget notifications at $0.25 and the defensive action near
+   $0.45.
+6. Deploy first through `dev`, upload and download one CSV and one text evidence
+   file, then verify object metadata, breaker counters, and deletion.
+7. Confirm cross-workspace source reads return `404`, expired source reads return
+   `404`, and a forced breaker returns `507` without an S3 call.
+8. Promote to `main` only after backend, frontend, PostgreSQL, browser, secret,
+   and public smoke gates pass.
+
+## Consequences
+
+Positive consequences:
+
+- Exact source files can be recovered briefly without storing bytes in
+  PostgreSQL.
+- CarbonSage demonstrates a production-relevant AWS integration and explicit
+  cost governance.
+- The object store can support future bounded reprocessing and selected-file
+  imports without becoming the domain database.
+- A provider adapter and durable ledger keep authorization, retention, and
+  budget policy in application code.
+
+Trade-offs:
+
+- S3 is no longer literally free after promotional allowances, although the
+  expected demo charge is normally below one cent and the priced hard envelope
+  is approximately $0.379.
+- Proxying downloads through Render is simpler and safer but consumes Render
+  bandwidth. Direct presigned transfer is deferred until replay and cost
+  controls are designed.
+- Cleanup is opportunistic rather than worker-driven. The lifecycle rule is
+  therefore mandatory.
+- The $0.50 claim is S3-specific, pre-tax, and depends on exclusive use of the
+  scoped runtime path. It is not an account-wide AWS spending guarantee.
+
+## References
+
+- [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/)
+- [AWS Free Tier](https://aws.amazon.com/free/)
+- [AWS Budgets behavior](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)
+- [S3 lifecycle configuration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+- [S3 public-access blocking](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html)

--- a/docs/demo-roadmap.md
+++ b/docs/demo-roadmap.md
@@ -10,6 +10,12 @@ migration is justified.
 The project remains a lean modular monolith, not a GraphQL or microservice
 migration.
 
+Validated shipment and evidence source files now have an approved private AWS
+S3 boundary. They are retained for at most 24 hours under a PostgreSQL-backed
+application breaker priced below USD $0.50/month. The rationale, exact limits,
+security controls, and activation runbook are recorded in
+[`decisions/001-aws-s3-artifact-source-storage.md`](decisions/001-aws-s3-artifact-source-storage.md).
+
 The post-initial-release opportunity across `carbonsage.org`,
 `app.carbonsage.ca`, supplier accounts, and a possible marketplace is preserved
 in [`carbonsage-ecosystem-vision.md`](carbonsage-ecosystem-vision.md). That
@@ -72,7 +78,8 @@ the CarbonSage infrastructure cleanup is recorded through commit `015abf0`:
 The next work should be hardening and measured product improvements, not a
 return to the abandoned GraphQL or embedder branches. ChromaDB, the standalone
 vector database used by the former retrieval prototype, is replaced by
-pgvector in the existing PostgreSQL deployment.
+pgvector in the existing PostgreSQL deployment. Source-object retention is a
+bounded S3 integration inside the same API, not a storage microservice.
 
 ## CarbonSage initial objective
 
@@ -164,6 +171,9 @@ PostgreSQL
 ├── suppliers and structured attributes
 ├── documents, chunks, and citations
 └── scenarios and report snapshots
+             │
+             └── private AWS S3
+                 └── validated source bytes, maximum 24 hours
 ```
 
 No Redis, message broker, dedicated embedder, former ChromaDB service, MongoDB, GraphQL
@@ -174,8 +184,8 @@ For initial document retrieval:
 - extract text during a bounded upload request;
 - store normalized text chunks and document metadata;
 - use PostgreSQL full-text search and structured filters;
-- retain the original file only temporarily unless a later requirement proves
-  it is necessary;
+- retain validated shipment and evidence originals privately in S3 for no more
+  than 24 hours, with exact workspace authorization and hard cost breakers;
 - keep a retrieval interface that supports the required pgvector semantic path
   and deterministic hybrid evaluation.
 
@@ -189,7 +199,8 @@ Preferred shape:
 - One Render web service for FastAPI.
 - One small managed PostgreSQL database, preferably on the same provider.
 - No always-on embedding service.
-- No paid object storage for the initial bounded demo.
+- One private S3 Standard bucket in Canada Central, bounded to an estimated
+  maximum of $0.379/month and an approved S3 ceiling below $0.50/month.
 - No mandatory paid LLM API.
 
 Public demo limits:
@@ -201,6 +212,8 @@ Public demo limits:
 - Maximum 10 analysis/scenario runs per workspace per day.
 - Maximum 3 optional assistant requests per workspace per day when enabled.
 - Workspace and extracted document retention of 24 hours by default.
+- Source-object storage limits of 4 GB active, 10,000 writes, 100,000 reads, and
+  2 GB metered egress per calendar month, enforced before provider calls.
 - Hard server-side timeouts and upload limits.
 
 If the selected Render plan and database cannot stay under the ceiling, the
@@ -605,6 +618,26 @@ Verification:
 - Two workspaces cannot read, mutate, or infer each other's artifacts.
 - Deleting an artifact has deterministic, tested behavior for derived records.
 - Raw file retention remains bounded and documented.
+
+Follow-on source-retention implementation (approved August 9, 2026; production
+activation remains gated):
+
+- Migration `006_artifact_object_storage.sql` adds durable source-object state,
+  global byte reservations, and monthly write/read/egress counters without
+  coupling cleanup records to expiring workspace rows.
+- The provider-neutral artifact storage service uses a narrow boto3 S3 adapter,
+  content-addressed workspace keys, SSE-S3, integrity validation, API-proxied
+  downloads, and retryable physical deletion.
+- Shipment and evidence uploads expose `source_retention` metadata. The artifact
+  catalog offers source download only while a retained object is active;
+  generated report snapshots remain PostgreSQL-only.
+- The application rejects an operation with `507` before it can cross the
+  configured storage/request/egress envelope. At Canada Central rates, the
+  priced maximum is approximately `$0.379`, leaving margin below `$0.50` even
+  without credits or free egress.
+- `infra/aws/artifact-storage.yaml` defines the private encrypted bucket,
+  one-day lifecycle backstop, public-access blocking, TLS policy, and scoped IAM
+  runtime policy. No credential or external resource is created by CI.
 
 Exit gate:
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -19,6 +19,7 @@ flowchart LR
     A[Browser] --> B[Next.js on Vercel free tier]
     B --> C[FastAPI on one Render web service]
     C --> D[Neon free PostgreSQL database]
+    C --> F[Private AWS S3 source storage]
     C -. optional .-> E[OpenAI or OpenRouter provider]
 ```
 
@@ -26,9 +27,10 @@ The assistant provider is optional. The primary shipment, evidence, scenario,
 and report workflow must work without it.
 
 No Redis, message broker, MongoDB, former ChromaDB service, dedicated embedding
-service, background worker, or paid object storage is required for the public
-demo or the CarbonSage initial track. Semantic retrieval uses pgvector in the
-existing PostgreSQL deployment rather than a new vector service.
+service, background worker, or storage microservice is required for the public
+demo or CarbonSage initial track. Semantic retrieval uses pgvector in the
+existing PostgreSQL deployment. Validated source files use one private S3
+bucket with a separate application-enforced ceiling below USD $0.50/month.
 
 ## Local baseline
 
@@ -54,8 +56,10 @@ docker compose up --build
 Compose uses the pinned `pgvector/pgvector:0.8.6-pg16-bookworm` image and
 applies the checked-in migrations for workspace, evidence, and vector records.
 Migration `005_artifact_catalog.sql` adds the workspace artifact catalog,
-source links, and typed report snapshots without adding object storage or a
-new service.
+source links, and typed report snapshots. Migration
+`006_artifact_object_storage.sql` adds the durable breaker ledger and private
+source-object metadata; local storage remains explicitly disabled unless its
+environment switch is enabled.
 Native development without `DATABASE_URL` uses the explicitly documented
 in-memory adapter; production must configure a managed PostgreSQL URL.
 
@@ -111,6 +115,28 @@ merge into `dev` for CI and evaluation without deploying either public service.
 - keep artifact, retrieval, conversation, embed-auth, and typed-tool modules in
   the same deployable service.
 
+### Object storage
+
+- one S3 Standard bucket in `ca-central-1`;
+- private, TLS-only, bucket-owner-enforced access with complete public-access
+  blocking and SSE-S3 encryption;
+- one-day expiration and incomplete-multipart cleanup as the provider backstop;
+- a runtime IAM policy scoped to location lookup and PUT/GET/DELETE under
+  `workspaces/*`;
+- PostgreSQL reservations before each S3 operation: 4 GB active storage,
+  10,000 writes, 100,000 reads, and 2 GB egress per month;
+- an estimated priced maximum of `$0.379` and rejected startup configuration if
+  limits reach the approved `$0.50` S3 ceiling;
+- API-proxied transfers only; no public or presigned URLs in the initial slice.
+
+The checked-in CloudFormation handoff is
+[`infra/aws/artifact-storage.yaml`](../infra/aws/artifact-storage.yaml). Set
+`ARTIFACT_STORAGE_ENABLED=true`, `AWS_S3_BUCKET`, `AWS_S3_REGION`, and the
+standard AWS credential variables in Render only after the bucket, lifecycle,
+IAM policy, and AWS Budget alerts have been verified. The full decision and
+activation checklist are in
+[`decisions/001-aws-s3-artifact-source-storage.md`](decisions/001-aws-s3-artifact-source-storage.md).
+
 ### Database
 
 - one small Neon PostgreSQL project using its Free plan for this bounded demo;
@@ -152,8 +178,9 @@ The backend must enforce the public limits from the roadmap:
 - 10 analysis or scenario runs per workspace per day (enforced server-side);
 - 3 assistant requests per workspace per day when enabled.
 
-Original evidence files should be temporary in the initial bounded demo.
-Normalized text, metadata, and citations live in PostgreSQL until workspace
+Original shipment and evidence files are private and downloadable only until
+their workspace/source expiry, never longer than 24 hours. Normalized text,
+metadata, citations, and report snapshots live in PostgreSQL until workspace
 expiry.
 
 ## Deployment safety

--- a/infra/aws/artifact-storage.yaml
+++ b/infra/aws/artifact-storage.yaml
@@ -1,0 +1,84 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  CarbonSage private 24-hour artifact source storage and least-privilege runtime policy.
+
+Parameters:
+  BucketName:
+    Type: String
+    Description: Globally unique private S3 bucket name for CarbonSage artifact sources.
+
+Resources:
+  ArtifactSourceBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Ref BucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteArtifactSourcesAfterOneDay
+            Status: Enabled
+            ExpirationInDays: 1
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Suspended
+
+  RequireTlsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ArtifactSourceBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: s3:*
+            Resource:
+              - !GetAtt ArtifactSourceBucket.Arn
+              - !Sub "${ArtifactSourceBucket.Arn}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
+
+  ArtifactStorageRuntimePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: CarbonSage API access to private workspace artifact source objects only.
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ReadBucketRegion
+            Effect: Allow
+            Action: s3:GetBucketLocation
+            Resource: !GetAtt ArtifactSourceBucket.Arn
+          - Sid: ManageWorkspaceArtifactSources
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:DeleteObject
+            Resource: !Sub "${ArtifactSourceBucket.Arn}/workspaces/*"
+
+Outputs:
+  BucketName:
+    Value: !Ref ArtifactSourceBucket
+  BucketArn:
+    Value: !GetAtt ArtifactSourceBucket.Arn
+  RuntimePolicyArn:
+    Value: !Ref ArtifactStorageRuntimePolicy
+  Region:
+    Value: !Ref AWS::Region

--- a/nzeroesg-api/.env.example
+++ b/nzeroesg-api/.env.example
@@ -20,3 +20,18 @@ EMBEDDING_DIMENSIONS=1536
 
 # Optional legacy estimate provider. The local fallback works without it.
 CARBON_INTERFACE_API_KEY=
+
+# Optional private AWS S3 source-file retention. Keep disabled until the bucket,
+# scoped IAM credentials, lifecycle rule, and durable PostgreSQL breaker ledger
+# are configured. The defaults enforce an estimated S3 ceiling below USD $0.50.
+ARTIFACT_STORAGE_ENABLED=false
+AWS_S3_BUCKET=
+AWS_S3_REGION=ca-central-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+ARTIFACT_STORAGE_RETENTION_HOURS=24
+ARTIFACT_STORAGE_MAX_ACTIVE_BYTES=4000000000
+ARTIFACT_STORAGE_MAX_WORKSPACE_BYTES=55000000
+ARTIFACT_STORAGE_MAX_WRITE_REQUESTS=10000
+ARTIFACT_STORAGE_MAX_READ_REQUESTS=100000
+ARTIFACT_STORAGE_MAX_EGRESS_BYTES=2000000000

--- a/nzeroesg-api/Dockerfile
+++ b/nzeroesg-api/Dockerfile
@@ -14,7 +14,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY agent ./agent
 COPY api ./api
 COPY domain ./domain
+COPY integrations ./integrations
 COPY persistence ./persistence
+COPY services ./services
 COPY config.py main.py ./
 
 USER app

--- a/nzeroesg-api/api/artifacts.py
+++ b/nzeroesg-api/api/artifacts.py
@@ -3,23 +3,57 @@
 from __future__ import annotations
 
 from typing import Annotated, Any
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from api.workspaces import require_workspace_principal
-from config import database_url_for_runtime
+from config import database_url_for_runtime, settings, validate_artifact_storage_runtime
 from domain.artifacts.models import Artifact, ArtifactKind, ArtifactSourceType, ArtifactStatus
+from domain.artifacts.storage import (
+    ArtifactStorageBudgetExceededError,
+    ArtifactStorageNotFoundError,
+    ArtifactStoragePolicy,
+    ArtifactStorageProviderError,
+    SourceRetention,
+)
 from domain.workspaces.principals import WorkspacePrincipal
+from integrations.aws_s3 import S3ObjectStore
+from persistence.artifact_storage import build_artifact_storage_repository
 from persistence.artifacts import (
     ArtifactNotFoundError,
     build_artifact_repository,
     build_report_snapshot_repository,
 )
+from services.artifact_storage import ArtifactStorageService
 
 artifacts_router = APIRouter(prefix="/artifacts", tags=["artifacts"])
 artifact_repository = build_artifact_repository(database_url_for_runtime())
 report_snapshot_repository = build_report_snapshot_repository(database_url_for_runtime())
+validate_artifact_storage_runtime()
+artifact_storage_policy = ArtifactStoragePolicy(
+    max_active_storage_bytes=settings.artifact_storage_max_active_bytes,
+    max_workspace_storage_bytes=settings.artifact_storage_max_workspace_bytes,
+    max_write_requests_per_month=settings.artifact_storage_max_write_requests,
+    max_read_requests_per_month=settings.artifact_storage_max_read_requests,
+    max_egress_bytes_per_month=settings.artifact_storage_max_egress_bytes,
+    retention_hours=settings.artifact_storage_retention_hours,
+)
+artifact_storage_repository = build_artifact_storage_repository(database_url_for_runtime())
+artifact_object_store = (
+    S3ObjectStore(bucket=settings.aws_s3_bucket or "", region=settings.aws_s3_region)
+    if settings.artifact_storage_enabled
+    else None
+)
+artifact_storage_service = ArtifactStorageService(
+    enabled=settings.artifact_storage_enabled,
+    repository=artifact_storage_repository,
+    policy=artifact_storage_policy,
+    object_store=artifact_object_store,
+    bucket=settings.aws_s3_bucket or "",
+)
 
 
 class ArtifactResponse(BaseModel):
@@ -59,6 +93,55 @@ def _not_found() -> HTTPException:
     )
 
 
+def _storage_exception(exc: Exception) -> HTTPException:
+    if isinstance(exc, ArtifactStorageBudgetExceededError):
+        return HTTPException(
+            status_code=status.HTTP_507_INSUFFICIENT_STORAGE,
+            detail=(
+                "The monthly artifact-retention safety limit has been reached. "
+                "The source file was not stored."
+            ),
+        )
+    if isinstance(exc, ArtifactStorageNotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Retained source content is unavailable or has expired.",
+        )
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Private artifact source storage is temporarily unavailable.",
+    )
+
+
+async def retain_artifact_source(
+    artifact: Artifact,
+    content: bytes,
+    *,
+    workspace_expires_at: int,
+) -> SourceRetention:
+    try:
+        return await run_in_threadpool(
+            artifact_storage_service.retain,
+            artifact,
+            content,
+            workspace_expires_at=workspace_expires_at,
+        )
+    except (
+        ArtifactStorageBudgetExceededError,
+        ArtifactStorageNotFoundError,
+        ArtifactStorageProviderError,
+    ) as exc:
+        raise _storage_exception(exc) from exc
+
+
+async def schedule_artifact_source_delete(workspace_id: str, artifact_id: str) -> bool:
+    return await run_in_threadpool(
+        artifact_storage_service.schedule_delete,
+        workspace_id,
+        artifact_id,
+    )
+
+
 @artifacts_router.get("", response_model=ArtifactListResponse)
 async def list_artifacts(
     principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
@@ -80,6 +163,38 @@ async def get_artifact(
     if artifact is None:
         raise _not_found()
     return artifact_response(artifact)
+
+
+@artifacts_router.get("/{artifact_id}/content")
+async def download_artifact_source(
+    artifact_id: str,
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
+) -> Response:
+    artifact = artifact_repository.get(principal.workspace_id, artifact_id)
+    if artifact is None:
+        raise _not_found()
+    try:
+        source, content = await run_in_threadpool(
+            artifact_storage_service.download,
+            principal.workspace_id,
+            artifact_id,
+        )
+    except (
+        ArtifactStorageBudgetExceededError,
+        ArtifactStorageNotFoundError,
+        ArtifactStorageProviderError,
+    ) as exc:
+        raise _storage_exception(exc) from exc
+    encoded_filename = quote(artifact.title, safe="")
+    return Response(
+        content=content,
+        media_type=source.media_type,
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
+            "Cache-Control": "private, no-store",
+            "X-Content-SHA256": source.content_sha256,
+        },
+    )
 
 
 @artifacts_router.patch("/{artifact_id}", response_model=ArtifactResponse)
@@ -113,6 +228,7 @@ async def delete_artifact(
     if artifact is None:
         raise _not_found()
 
+    await schedule_artifact_source_delete(principal.workspace_id, artifact_id)
     artifact_repository.soft_delete(principal.workspace_id, artifact_id)
 
     # Imports are intentionally local: the API modules share repository instances,

--- a/nzeroesg-api/api/evidence.py
+++ b/nzeroesg-api/api/evidence.py
@@ -7,7 +7,13 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Upload
 from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 
-from api.artifacts import ArtifactResponse, artifact_repository, artifact_response
+from api.artifacts import (
+    ArtifactResponse,
+    artifact_repository,
+    artifact_response,
+    retain_artifact_source,
+    schedule_artifact_source_delete,
+)
 from api.workspaces import require_workspace_principal, workspace_repository
 from config import database_url_for_runtime, settings
 from domain.artifacts.models import ArtifactKind, ArtifactSourceType, create_artifact
@@ -287,6 +293,11 @@ async def upload_evidence(
     )
     artifact_repository.create(artifact)
     try:
+        source_retention = await retain_artifact_source(
+            artifact,
+            content,
+            workspace_expires_at=principal.expires_at,
+        )
         stored_supplier = evidence_repository.store(
             principal.workspace_id,
             artifact.artifact_id,
@@ -303,9 +314,14 @@ async def upload_evidence(
                 "page_count": extraction.document.page_count,
                 "chunk_count": len(extraction.document.chunks),
                 "embedding_status": embedding_status,
+                "source_retention": source_retention.to_dict(),
             },
         )
     except Exception:
+        await schedule_artifact_source_delete(
+            principal.workspace_id,
+            artifact.artifact_id,
+        )
         artifact_repository.mark_failed(principal.workspace_id, artifact.artifact_id)
         raise
     return EvidenceUploadResponse(

--- a/nzeroesg-api/api/shipments.py
+++ b/nzeroesg-api/api/shipments.py
@@ -6,7 +6,13 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel
 
-from api.artifacts import ArtifactResponse, artifact_repository, artifact_response
+from api.artifacts import (
+    ArtifactResponse,
+    artifact_repository,
+    artifact_response,
+    retain_artifact_source,
+    schedule_artifact_source_delete,
+)
 from api.workspaces import require_workspace_principal, workspace_repository
 from config import database_url_for_runtime
 from domain.artifacts.models import Artifact, ArtifactKind, ArtifactSourceType, create_artifact
@@ -149,6 +155,11 @@ async def upload_shipments(
     artifact = None
     if parsed.rows:
         _consume_analysis_run(principal.workspace_id)
+        prior_shipments = tuple(
+            item
+            for item in artifact_repository.list_for_workspace(principal.workspace_id)
+            if item.kind is ArtifactKind.SHIPMENT_DATASET
+        )
         artifact = create_artifact(
             workspace_id=principal.workspace_id,
             kind=ArtifactKind.SHIPMENT_DATASET,
@@ -161,6 +172,11 @@ async def upload_shipments(
         )
         artifact_repository.create(artifact)
         try:
+            source_retention = await retain_artifact_source(
+                artifact,
+                content,
+                workspace_expires_at=principal.expires_at,
+            )
             shipment_repository.replace_for_workspace(
                 principal.workspace_id,
                 artifact.artifact_id,
@@ -173,13 +189,23 @@ async def upload_shipments(
                     "accepted_rows": len(parsed.rows),
                     "validation_error_count": len(parsed.errors),
                     "warning_count": len(parsed.warnings),
+                    "source_retention": source_retention.to_dict(),
                 },
             )
+            for prior in prior_shipments:
+                await schedule_artifact_source_delete(
+                    principal.workspace_id,
+                    prior.artifact_id,
+                )
             artifact_repository.soft_delete_other_ready_shipments(
                 principal.workspace_id,
                 artifact.artifact_id,
             )
         except Exception:
+            await schedule_artifact_source_delete(
+                principal.workspace_id,
+                artifact.artifact_id,
+            )
             artifact_repository.mark_failed(principal.workspace_id, artifact.artifact_id)
             raise
     return _response(

--- a/nzeroesg-api/config.py
+++ b/nzeroesg-api/config.py
@@ -45,6 +45,25 @@ class Settings:
     embedding_model: str | None = os.getenv("EMBEDDING_MODEL") or None
     embedding_dimensions: int = int(os.getenv("EMBEDDING_DIMENSIONS", "1536"))
     carbon_interface_api_key: str | None = os.getenv("CARBON_INTERFACE_API_KEY")
+    artifact_storage_enabled: bool = _as_bool(os.getenv("ARTIFACT_STORAGE_ENABLED"))
+    aws_s3_bucket: str | None = os.getenv("AWS_S3_BUCKET") or None
+    aws_s3_region: str = os.getenv("AWS_S3_REGION", "ca-central-1")
+    artifact_storage_retention_hours: int = int(os.getenv("ARTIFACT_STORAGE_RETENTION_HOURS", "24"))
+    artifact_storage_max_active_bytes: int = int(
+        os.getenv("ARTIFACT_STORAGE_MAX_ACTIVE_BYTES", "4000000000")
+    )
+    artifact_storage_max_workspace_bytes: int = int(
+        os.getenv("ARTIFACT_STORAGE_MAX_WORKSPACE_BYTES", "55000000")
+    )
+    artifact_storage_max_write_requests: int = int(
+        os.getenv("ARTIFACT_STORAGE_MAX_WRITE_REQUESTS", "10000")
+    )
+    artifact_storage_max_read_requests: int = int(
+        os.getenv("ARTIFACT_STORAGE_MAX_READ_REQUESTS", "100000")
+    )
+    artifact_storage_max_egress_bytes: int = int(
+        os.getenv("ARTIFACT_STORAGE_MAX_EGRESS_BYTES", "2000000000")
+    )
     cors_origins: tuple[str, ...] = _as_csv(
         os.getenv("CORS_ORIGINS"),
         default=("http://localhost:3000", "http://127.0.0.1:3000"),
@@ -60,3 +79,18 @@ def database_url_for_runtime() -> str | None:
     if settings.environment == "production" and not settings.database_url:
         raise RuntimeError("DATABASE_URL is required when APP_ENV=production.")
     return settings.database_url
+
+
+def validate_artifact_storage_runtime() -> None:
+    """Fail closed on a configuration that cannot enforce the approved budget."""
+
+    if not settings.artifact_storage_enabled:
+        return
+    if not settings.database_url:
+        raise RuntimeError("DATABASE_URL is required when ARTIFACT_STORAGE_ENABLED=true.")
+    if not settings.aws_s3_bucket:
+        raise RuntimeError("AWS_S3_BUCKET is required when ARTIFACT_STORAGE_ENABLED=true.")
+    if settings.aws_s3_region != "ca-central-1":
+        raise RuntimeError(
+            "The approved artifact storage cost policy currently requires ca-central-1."
+        )

--- a/nzeroesg-api/domain/artifacts/storage.py
+++ b/nzeroesg-api/domain/artifacts/storage.py
@@ -1,0 +1,146 @@
+"""Provider-neutral artifact source-retention contracts and cost policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from enum import StrEnum
+
+
+class ArtifactObjectStatus(StrEnum):
+    RESERVED = "reserved"
+    READY = "ready"
+    DELETE_PENDING = "delete_pending"
+    DELETED = "deleted"
+    FAILED = "failed"
+
+
+class ArtifactStorageError(RuntimeError):
+    """Base error for retained artifact source operations."""
+
+
+class ArtifactStorageNotFoundError(ArtifactStorageError, LookupError):
+    """Raised when retained source bytes are unavailable to the workspace."""
+
+
+class ArtifactStorageBudgetExceededError(ArtifactStorageError):
+    """Raised before an operation that would cross a configured cost guardrail."""
+
+    def __init__(self, dimension: str) -> None:
+        self.dimension = dimension
+        super().__init__(f"Artifact storage {dimension} budget has been reached.")
+
+
+class ArtifactStorageProviderError(ArtifactStorageError):
+    """Raised when the configured object-store provider cannot complete an operation."""
+
+
+@dataclass(frozen=True)
+class ArtifactStoragePolicy:
+    """Hard application limits priced for AWS S3 Standard in Canada Central.
+
+    The estimate intentionally ignores promotional credits and the recurring
+    account-wide AWS data-transfer allowance. This leaves room below the
+    approved USD 0.50 S3 service ceiling for pricing drift and incidental
+    operations. Taxes, currency conversion, and unrelated AWS services are
+    outside this service-specific envelope.
+    """
+
+    max_active_storage_bytes: int = 4_000_000_000
+    max_workspace_storage_bytes: int = 55_000_000
+    max_write_requests_per_month: int = 10_000
+    max_read_requests_per_month: int = 100_000
+    max_egress_bytes_per_month: int = 2_000_000_000
+    retention_hours: int = 24
+    billing_ceiling_usd: Decimal = Decimal("0.50")
+    storage_usd_per_gb_month: Decimal = Decimal("0.025")
+    writes_usd_per_1000: Decimal = Decimal("0.0055")
+    reads_usd_per_10000: Decimal = Decimal("0.0044")
+    egress_usd_per_gb: Decimal = Decimal("0.09")
+
+    def __post_init__(self) -> None:
+        integer_limits = (
+            self.max_active_storage_bytes,
+            self.max_workspace_storage_bytes,
+            self.max_write_requests_per_month,
+            self.max_read_requests_per_month,
+            self.max_egress_bytes_per_month,
+            self.retention_hours,
+        )
+        if any(limit <= 0 for limit in integer_limits):
+            raise ValueError("Artifact storage limits must be positive.")
+        if self.max_workspace_storage_bytes > self.max_active_storage_bytes:
+            raise ValueError("Workspace storage cannot exceed the global storage limit.")
+        if self.retention_hours > 24:
+            raise ValueError("Artifact source retention cannot exceed 24 hours.")
+        if self.estimated_maximum_monthly_cost_usd() >= self.billing_ceiling_usd:
+            raise ValueError("Artifact storage limits do not leave room below the billing ceiling.")
+
+    def estimated_maximum_monthly_cost_usd(self) -> Decimal:
+        bytes_per_decimal_gb = Decimal(1_000_000_000)
+        storage = (
+            Decimal(self.max_active_storage_bytes)
+            / bytes_per_decimal_gb
+            * self.storage_usd_per_gb_month
+        )
+        writes = (
+            Decimal(self.max_write_requests_per_month) / Decimal(1_000) * self.writes_usd_per_1000
+        )
+        reads = (
+            Decimal(self.max_read_requests_per_month) / Decimal(10_000) * self.reads_usd_per_10000
+        )
+        egress = (
+            Decimal(self.max_egress_bytes_per_month) / bytes_per_decimal_gb * self.egress_usd_per_gb
+        )
+        return storage + writes + reads + egress
+
+
+@dataclass(frozen=True)
+class ArtifactObject:
+    artifact_id: str
+    workspace_id: str
+    provider: str
+    bucket: str
+    object_key: str
+    size_bytes: int
+    content_sha256: str
+    media_type: str
+    status: ArtifactObjectStatus
+    expires_at: datetime
+    etag: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    stored_at: datetime | None = None
+    deleted_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.size_bytes <= 0:
+            raise ValueError("Artifact source size must be positive.")
+        if len(self.content_sha256) != 64:
+            raise ValueError("Artifact source hash must be a SHA-256 digest.")
+        if self.expires_at.tzinfo is None:
+            raise ValueError("Artifact source expiry must be timezone-aware.")
+
+
+@dataclass(frozen=True)
+class ArtifactStorageUsage:
+    period_start: date
+    active_bytes: int
+    reserved_bytes: int
+    write_requests: int
+    read_requests: int
+    egress_bytes: int
+
+
+@dataclass(frozen=True)
+class SourceRetention:
+    status: str
+    size_bytes: int | None = None
+    expires_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, int | str | None]:
+        return {
+            "status": self.status,
+            "size_bytes": self.size_bytes,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+        }

--- a/nzeroesg-api/integrations/__init__.py
+++ b/nzeroesg-api/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""External provider adapters."""

--- a/nzeroesg-api/integrations/aws_s3.py
+++ b/nzeroesg-api/integrations/aws_s3.py
@@ -1,0 +1,132 @@
+"""Narrow AWS S3 adapter for private, short-lived artifact source objects."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+try:
+    import boto3
+    from botocore.config import Config
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:  # pragma: no cover - dependency is present in deployed/runtime installs
+    boto3 = None
+    Config = None
+    BotoCoreError = ClientError = Exception
+
+from domain.artifacts.storage import ArtifactStorageProviderError
+
+
+class ObjectStore(Protocol):
+    def put(
+        self,
+        object_key: str,
+        content: bytes,
+        *,
+        media_type: str,
+        content_sha256: str,
+    ) -> str | None: ...
+
+    def get(self, object_key: str) -> bytes: ...
+
+    def delete(self, object_key: str) -> None: ...
+
+
+class InMemoryObjectStore:
+    """Deterministic object store used by service and API tests."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    def put(
+        self,
+        object_key: str,
+        content: bytes,
+        *,
+        media_type: str,
+        content_sha256: str,
+    ) -> str:
+        self.objects[object_key] = bytes(content)
+        return f'"test-{content_sha256[:16]}"'
+
+    def get(self, object_key: str) -> bytes:
+        try:
+            return self.objects[object_key]
+        except KeyError as exc:
+            raise ArtifactStorageProviderError("Stored artifact source is unavailable.") from exc
+
+    def delete(self, object_key: str) -> None:
+        self.objects.pop(object_key, None)
+
+
+class S3ObjectStore:
+    """AWS SDK adapter restricted to PUT, GET, and DELETE on one private bucket."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        region: str,
+        client: Any | None = None,
+    ) -> None:
+        if not bucket:
+            raise ValueError("AWS_S3_BUCKET is required.")
+        if not region:
+            raise ValueError("AWS_S3_REGION is required.")
+        if client is None:
+            if boto3 is None:
+                raise RuntimeError("boto3 is required when artifact storage is enabled.")
+            client = boto3.client(
+                "s3",
+                region_name=region,
+                config=Config(retries={"total_max_attempts": 1, "mode": "standard"}),
+            )
+        self.bucket = bucket
+        self.region = region
+        self._client = client
+
+    def put(
+        self,
+        object_key: str,
+        content: bytes,
+        *,
+        media_type: str,
+        content_sha256: str,
+    ) -> str | None:
+        try:
+            response = self._client.put_object(
+                Bucket=self.bucket,
+                Key=object_key,
+                Body=content,
+                ContentLength=len(content),
+                ContentType=media_type,
+                Metadata={"content-sha256": content_sha256},
+                ServerSideEncryption="AES256",
+            )
+        except (BotoCoreError, ClientError) as exc:
+            raise ArtifactStorageProviderError(
+                "AWS S3 could not retain the artifact source."
+            ) from exc
+        return response.get("ETag")
+
+    def get(self, object_key: str) -> bytes:
+        try:
+            response = self._client.get_object(Bucket=self.bucket, Key=object_key)
+            body = response["Body"]
+            try:
+                return body.read()
+            finally:
+                close = getattr(body, "close", None)
+                if close:
+                    close()
+        except (BotoCoreError, ClientError, KeyError) as exc:
+            raise ArtifactStorageProviderError(
+                "AWS S3 could not read the artifact source."
+            ) from exc
+
+    def delete(self, object_key: str) -> None:
+        try:
+            self._client.delete_object(Bucket=self.bucket, Key=object_key)
+        except (BotoCoreError, ClientError) as exc:
+            raise ArtifactStorageProviderError(
+                "AWS S3 could not delete the artifact source."
+            ) from exc

--- a/nzeroesg-api/main.py
+++ b/nzeroesg-api/main.py
@@ -57,4 +57,5 @@ async def health():
         "environment": settings.environment,
         "assistant_enabled": settings.assistant_enabled,
         "semantic_search_enabled": bool(settings.embedding_provider),
+        "artifact_storage_enabled": settings.artifact_storage_enabled,
     }

--- a/nzeroesg-api/persistence/artifact_storage.py
+++ b/nzeroesg-api/persistence/artifact_storage.py
@@ -1,0 +1,727 @@
+"""Durable source-object metadata and application-side S3 cost breakers."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import closing
+from dataclasses import replace
+from datetime import UTC, date, datetime
+from typing import Any, Protocol
+
+try:
+    import psycopg
+except ImportError:  # pragma: no cover - exercised only before optional local setup
+    psycopg = None
+
+from domain.artifacts.storage import (
+    ArtifactObject,
+    ArtifactObjectStatus,
+    ArtifactStorageBudgetExceededError,
+    ArtifactStorageNotFoundError,
+    ArtifactStoragePolicy,
+    ArtifactStorageUsage,
+)
+
+
+def _period_start(now: datetime) -> date:
+    return date(now.year, now.month, 1)
+
+
+def _clone(value: ArtifactObject) -> ArtifactObject:
+    return replace(value)
+
+
+class ArtifactStorageRepository(Protocol):
+    def reserve_upload(
+        self,
+        source: ArtifactObject,
+        policy: ArtifactStoragePolicy,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject: ...
+
+    def mark_stored(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        etag: str | None,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject: ...
+
+    def mark_upload_failed(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> None: ...
+
+    def get_ready(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject | None: ...
+
+    def reserve_download(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        policy: ArtifactStoragePolicy,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject: ...
+
+    def mark_delete_pending(self, workspace_id: str, artifact_id: str) -> None: ...
+
+    def mark_deleted(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> None: ...
+
+    def cleanup_candidates(
+        self,
+        *,
+        now: datetime | None = None,
+        limit: int = 100,
+    ) -> tuple[ArtifactObject, ...]: ...
+
+    def usage(self, *, now: datetime | None = None) -> ArtifactStorageUsage: ...
+
+
+class InMemoryArtifactStorageRepository:
+    """Thread-safe breaker ledger for unit tests and credential-free development."""
+
+    def __init__(self) -> None:
+        self._objects: dict[tuple[str, str], ArtifactObject] = {}
+        self._active_bytes = 0
+        self._reserved_bytes = 0
+        self._monthly: dict[date, dict[str, int]] = {}
+        self._lock = threading.RLock()
+
+    def _month(self, now: datetime) -> dict[str, int]:
+        return self._monthly.setdefault(
+            _period_start(now),
+            {"write_requests": 0, "read_requests": 0, "egress_bytes": 0},
+        )
+
+    def reserve_upload(
+        self,
+        source: ArtifactObject,
+        policy: ArtifactStoragePolicy,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject:
+        timestamp = now or datetime.now(UTC)
+        key = (source.workspace_id, source.artifact_id)
+        with self._lock:
+            if key in self._objects:
+                raise ValueError("Artifact source already has a storage record.")
+            workspace_bytes = sum(
+                item.size_bytes
+                for item in self._objects.values()
+                if item.workspace_id == source.workspace_id
+                and item.status
+                in {
+                    ArtifactObjectStatus.RESERVED,
+                    ArtifactObjectStatus.READY,
+                    ArtifactObjectStatus.DELETE_PENDING,
+                }
+            )
+            if workspace_bytes + source.size_bytes > policy.max_workspace_storage_bytes:
+                raise ArtifactStorageBudgetExceededError("workspace storage")
+            if (
+                self._active_bytes + self._reserved_bytes + source.size_bytes
+                > policy.max_active_storage_bytes
+            ):
+                raise ArtifactStorageBudgetExceededError("active storage")
+            monthly = self._month(timestamp)
+            if monthly["write_requests"] + 1 > policy.max_write_requests_per_month:
+                raise ArtifactStorageBudgetExceededError("monthly write request")
+            monthly["write_requests"] += 1
+            self._reserved_bytes += source.size_bytes
+            reserved = replace(
+                source,
+                status=ArtifactObjectStatus.RESERVED,
+                created_at=timestamp,
+            )
+            self._objects[key] = reserved
+            return _clone(reserved)
+
+    def mark_stored(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        etag: str | None,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject:
+        timestamp = now or datetime.now(UTC)
+        key = (workspace_id, artifact_id)
+        with self._lock:
+            current = self._objects.get(key)
+            if current is None or current.status is not ArtifactObjectStatus.RESERVED:
+                raise ArtifactStorageNotFoundError(artifact_id)
+            self._reserved_bytes -= current.size_bytes
+            self._active_bytes += current.size_bytes
+            stored = replace(
+                current,
+                status=ArtifactObjectStatus.READY,
+                etag=etag,
+                stored_at=timestamp,
+            )
+            self._objects[key] = stored
+            return _clone(stored)
+
+    def mark_upload_failed(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> None:
+        key = (workspace_id, artifact_id)
+        with self._lock:
+            current = self._objects.get(key)
+            if current is None:
+                return
+            if current.status is ArtifactObjectStatus.RESERVED:
+                self._reserved_bytes -= current.size_bytes
+            self._objects[key] = replace(current, status=ArtifactObjectStatus.FAILED)
+
+    def get_ready(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject | None:
+        timestamp = now or datetime.now(UTC)
+        with self._lock:
+            current = self._objects.get((workspace_id, artifact_id))
+            if (
+                current is None
+                or current.status is not ArtifactObjectStatus.READY
+                or current.expires_at <= timestamp
+            ):
+                return None
+            return _clone(current)
+
+    def reserve_download(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        policy: ArtifactStoragePolicy,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject:
+        timestamp = now or datetime.now(UTC)
+        with self._lock:
+            source = self.get_ready(workspace_id, artifact_id, now=timestamp)
+            if source is None:
+                raise ArtifactStorageNotFoundError(artifact_id)
+            monthly = self._month(timestamp)
+            if monthly["read_requests"] + 1 > policy.max_read_requests_per_month:
+                raise ArtifactStorageBudgetExceededError("monthly read request")
+            if monthly["egress_bytes"] + source.size_bytes > policy.max_egress_bytes_per_month:
+                raise ArtifactStorageBudgetExceededError("monthly egress")
+            monthly["read_requests"] += 1
+            monthly["egress_bytes"] += source.size_bytes
+            return source
+
+    def mark_delete_pending(self, workspace_id: str, artifact_id: str) -> None:
+        key = (workspace_id, artifact_id)
+        with self._lock:
+            current = self._objects.get(key)
+            if current and current.status is ArtifactObjectStatus.READY:
+                self._objects[key] = replace(
+                    current,
+                    status=ArtifactObjectStatus.DELETE_PENDING,
+                )
+
+    def mark_deleted(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> None:
+        timestamp = now or datetime.now(UTC)
+        key = (workspace_id, artifact_id)
+        with self._lock:
+            current = self._objects.get(key)
+            if current is None or current.status is ArtifactObjectStatus.DELETED:
+                return
+            if current.status is ArtifactObjectStatus.RESERVED:
+                self._reserved_bytes -= current.size_bytes
+            elif current.status in {
+                ArtifactObjectStatus.READY,
+                ArtifactObjectStatus.DELETE_PENDING,
+            }:
+                self._active_bytes -= current.size_bytes
+            self._objects[key] = replace(
+                current,
+                status=ArtifactObjectStatus.DELETED,
+                deleted_at=timestamp,
+            )
+
+    def cleanup_candidates(
+        self,
+        *,
+        now: datetime | None = None,
+        limit: int = 100,
+    ) -> tuple[ArtifactObject, ...]:
+        timestamp = now or datetime.now(UTC)
+        with self._lock:
+            candidates = [
+                _clone(item)
+                for item in self._objects.values()
+                if item.status is ArtifactObjectStatus.DELETE_PENDING
+                or (item.status is ArtifactObjectStatus.READY and item.expires_at <= timestamp)
+            ]
+        candidates.sort(key=lambda item: (item.expires_at, item.artifact_id))
+        return tuple(candidates[:limit])
+
+    def usage(self, *, now: datetime | None = None) -> ArtifactStorageUsage:
+        timestamp = now or datetime.now(UTC)
+        with self._lock:
+            monthly = dict(self._month(timestamp))
+            return ArtifactStorageUsage(
+                period_start=_period_start(timestamp),
+                active_bytes=self._active_bytes,
+                reserved_bytes=self._reserved_bytes,
+                write_requests=monthly["write_requests"],
+                read_requests=monthly["read_requests"],
+                egress_bytes=monthly["egress_bytes"],
+            )
+
+
+def _object_from_row(row: tuple[Any, ...]) -> ArtifactObject:
+    return ArtifactObject(
+        artifact_id=str(row[0]),
+        workspace_id=row[1],
+        provider=row[2],
+        bucket=row[3],
+        object_key=row[4],
+        size_bytes=row[5],
+        content_sha256=row[6],
+        media_type=row[7],
+        status=ArtifactObjectStatus(row[8]),
+        expires_at=row[9],
+        etag=row[10],
+        created_at=row[11],
+        stored_at=row[12],
+        deleted_at=row[13],
+    )
+
+
+OBJECT_COLUMNS = """
+    artifact_id, workspace_id, provider, bucket, object_key, size_bytes,
+    content_sha256, media_type, status, expires_at, etag, created_at,
+    stored_at, deleted_at
+"""
+
+
+class PostgresArtifactStorageRepository:
+    """Transactional global and monthly breakers shared by all API instances."""
+
+    def __init__(self, database_url: str) -> None:
+        if psycopg is None:
+            raise RuntimeError("psycopg is required for durable artifact storage budgets.")
+        self.database_url = database_url
+
+    def _connect(self):
+        return psycopg.connect(self.database_url)
+
+    @staticmethod
+    def _lock_state(cursor) -> tuple[int, int]:
+        cursor.execute(
+            """
+            SELECT active_bytes, reserved_bytes
+            FROM artifact_storage_state
+            WHERE singleton = TRUE
+            FOR UPDATE
+            """
+        )
+        row = cursor.fetchone()
+        if row is None:  # pragma: no cover - migration invariant
+            raise RuntimeError("Artifact storage state is missing.")
+        return row[0], row[1]
+
+    @staticmethod
+    def _lock_month(cursor, period: date) -> tuple[int, int, int]:
+        cursor.execute(
+            """
+            INSERT INTO artifact_storage_monthly_usage (period_start)
+            VALUES (%s)
+            ON CONFLICT (period_start) DO NOTHING
+            """,
+            (period,),
+        )
+        cursor.execute(
+            """
+            SELECT write_requests, read_requests, egress_bytes
+            FROM artifact_storage_monthly_usage
+            WHERE period_start = %s
+            FOR UPDATE
+            """,
+            (period,),
+        )
+        return cursor.fetchone()
+
+    def reserve_upload(
+        self,
+        source: ArtifactObject,
+        policy: ArtifactStoragePolicy,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject:
+        timestamp = now or datetime.now(UTC)
+        period = _period_start(timestamp)
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                active_bytes, reserved_bytes = self._lock_state(cursor)
+                write_requests, _, _ = self._lock_month(cursor, period)
+                cursor.execute(
+                    """
+                    SELECT COALESCE(SUM(size_bytes), 0)
+                    FROM artifact_objects
+                    WHERE workspace_id = %s
+                      AND status IN ('reserved', 'ready', 'delete_pending')
+                    """,
+                    (source.workspace_id,),
+                )
+                workspace_bytes = cursor.fetchone()[0]
+                if workspace_bytes + source.size_bytes > policy.max_workspace_storage_bytes:
+                    connection.rollback()
+                    raise ArtifactStorageBudgetExceededError("workspace storage")
+                if (
+                    active_bytes + reserved_bytes + source.size_bytes
+                    > policy.max_active_storage_bytes
+                ):
+                    connection.rollback()
+                    raise ArtifactStorageBudgetExceededError("active storage")
+                if write_requests + 1 > policy.max_write_requests_per_month:
+                    connection.rollback()
+                    raise ArtifactStorageBudgetExceededError("monthly write request")
+                cursor.execute(
+                    f"""
+                    INSERT INTO artifact_objects ({OBJECT_COLUMNS})
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'reserved',
+                            %s, NULL, %s, NULL, NULL)
+                    RETURNING {OBJECT_COLUMNS}
+                    """,
+                    (
+                        source.artifact_id,
+                        source.workspace_id,
+                        source.provider,
+                        source.bucket,
+                        source.object_key,
+                        source.size_bytes,
+                        source.content_sha256,
+                        source.media_type,
+                        source.expires_at,
+                        timestamp,
+                    ),
+                )
+                row = cursor.fetchone()
+                cursor.execute(
+                    """
+                    UPDATE artifact_storage_state
+                    SET reserved_bytes = reserved_bytes + %s,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE singleton = TRUE
+                    """,
+                    (source.size_bytes,),
+                )
+                cursor.execute(
+                    """
+                    UPDATE artifact_storage_monthly_usage
+                    SET write_requests = write_requests + 1,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE period_start = %s
+                    """,
+                    (period,),
+                )
+            connection.commit()
+        return _object_from_row(row)
+
+    def mark_stored(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        etag: str | None,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject:
+        timestamp = now or datetime.now(UTC)
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                self._lock_state(cursor)
+                cursor.execute(
+                    """
+                    SELECT size_bytes
+                    FROM artifact_objects
+                    WHERE workspace_id = %s AND artifact_id = %s AND status = 'reserved'
+                    FOR UPDATE
+                    """,
+                    (workspace_id, artifact_id),
+                )
+                current = cursor.fetchone()
+                if current is None:
+                    connection.rollback()
+                    raise ArtifactStorageNotFoundError(artifact_id)
+                size_bytes = current[0]
+                cursor.execute(
+                    f"""
+                    UPDATE artifact_objects
+                    SET status = 'ready', etag = %s, stored_at = %s
+                    WHERE workspace_id = %s AND artifact_id = %s
+                    RETURNING {OBJECT_COLUMNS}
+                    """,
+                    (etag, timestamp, workspace_id, artifact_id),
+                )
+                row = cursor.fetchone()
+                cursor.execute(
+                    """
+                    UPDATE artifact_storage_state
+                    SET reserved_bytes = reserved_bytes - %s,
+                        active_bytes = active_bytes + %s,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE singleton = TRUE
+                    """,
+                    (size_bytes, size_bytes),
+                )
+            connection.commit()
+        return _object_from_row(row)
+
+    def mark_upload_failed(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> None:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                self._lock_state(cursor)
+                cursor.execute(
+                    """
+                    SELECT size_bytes
+                    FROM artifact_objects
+                    WHERE workspace_id = %s AND artifact_id = %s AND status = 'reserved'
+                    FOR UPDATE
+                    """,
+                    (workspace_id, artifact_id),
+                )
+                current = cursor.fetchone()
+                if current is None:
+                    connection.rollback()
+                    return
+                cursor.execute(
+                    """
+                    UPDATE artifact_objects SET status = 'failed'
+                    WHERE workspace_id = %s AND artifact_id = %s
+                    """,
+                    (workspace_id, artifact_id),
+                )
+                cursor.execute(
+                    """
+                    UPDATE artifact_storage_state
+                    SET reserved_bytes = reserved_bytes - %s,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE singleton = TRUE
+                    """,
+                    (current[0],),
+                )
+            connection.commit()
+
+    def get_ready(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject | None:
+        timestamp = now or datetime.now(UTC)
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT {OBJECT_COLUMNS}
+                    FROM artifact_objects
+                    WHERE workspace_id = %s AND artifact_id = %s
+                      AND status = 'ready' AND expires_at > %s
+                    """,
+                    (workspace_id, artifact_id, timestamp),
+                )
+                row = cursor.fetchone()
+        return _object_from_row(row) if row else None
+
+    def reserve_download(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        policy: ArtifactStoragePolicy,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactObject:
+        timestamp = now or datetime.now(UTC)
+        period = _period_start(timestamp)
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                _, read_requests, egress_bytes = self._lock_month(cursor, period)
+                cursor.execute(
+                    f"""
+                    SELECT {OBJECT_COLUMNS}
+                    FROM artifact_objects
+                    WHERE workspace_id = %s AND artifact_id = %s
+                      AND status = 'ready' AND expires_at > %s
+                    FOR UPDATE
+                    """,
+                    (workspace_id, artifact_id, timestamp),
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    connection.rollback()
+                    raise ArtifactStorageNotFoundError(artifact_id)
+                source = _object_from_row(row)
+                if read_requests + 1 > policy.max_read_requests_per_month:
+                    connection.rollback()
+                    raise ArtifactStorageBudgetExceededError("monthly read request")
+                if egress_bytes + source.size_bytes > policy.max_egress_bytes_per_month:
+                    connection.rollback()
+                    raise ArtifactStorageBudgetExceededError("monthly egress")
+                cursor.execute(
+                    """
+                    UPDATE artifact_storage_monthly_usage
+                    SET read_requests = read_requests + 1,
+                        egress_bytes = egress_bytes + %s,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE period_start = %s
+                    """,
+                    (source.size_bytes, period),
+                )
+            connection.commit()
+        return source
+
+    def mark_delete_pending(self, workspace_id: str, artifact_id: str) -> None:
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE artifact_objects SET status = 'delete_pending'
+                    WHERE workspace_id = %s AND artifact_id = %s AND status = 'ready'
+                    """,
+                    (workspace_id, artifact_id),
+                )
+            connection.commit()
+
+    def mark_deleted(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> None:
+        timestamp = now or datetime.now(UTC)
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                self._lock_state(cursor)
+                cursor.execute(
+                    """
+                    SELECT size_bytes, status
+                    FROM artifact_objects
+                    WHERE workspace_id = %s AND artifact_id = %s
+                    FOR UPDATE
+                    """,
+                    (workspace_id, artifact_id),
+                )
+                current = cursor.fetchone()
+                if current is None or current[1] == ArtifactObjectStatus.DELETED.value:
+                    connection.rollback()
+                    return
+                size_bytes, object_status = current
+                cursor.execute(
+                    """
+                    UPDATE artifact_objects
+                    SET status = 'deleted', deleted_at = %s
+                    WHERE workspace_id = %s AND artifact_id = %s
+                    """,
+                    (timestamp, workspace_id, artifact_id),
+                )
+                if object_status == ArtifactObjectStatus.RESERVED.value:
+                    cursor.execute(
+                        """
+                        UPDATE artifact_storage_state
+                        SET reserved_bytes = reserved_bytes - %s,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE singleton = TRUE
+                        """,
+                        (size_bytes,),
+                    )
+                elif object_status in {
+                    ArtifactObjectStatus.READY.value,
+                    ArtifactObjectStatus.DELETE_PENDING.value,
+                }:
+                    cursor.execute(
+                        """
+                        UPDATE artifact_storage_state
+                        SET active_bytes = active_bytes - %s,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE singleton = TRUE
+                        """,
+                        (size_bytes,),
+                    )
+            connection.commit()
+
+    def cleanup_candidates(
+        self,
+        *,
+        now: datetime | None = None,
+        limit: int = 100,
+    ) -> tuple[ArtifactObject, ...]:
+        timestamp = now or datetime.now(UTC)
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT {OBJECT_COLUMNS}
+                    FROM artifact_objects
+                    WHERE status = 'delete_pending'
+                       OR (status = 'ready' AND expires_at <= %s)
+                    ORDER BY expires_at, artifact_id
+                    LIMIT %s
+                    """,
+                    (timestamp, limit),
+                )
+                rows = cursor.fetchall()
+        return tuple(_object_from_row(row) for row in rows)
+
+    def usage(self, *, now: datetime | None = None) -> ArtifactStorageUsage:
+        timestamp = now or datetime.now(UTC)
+        period = _period_start(timestamp)
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                active_bytes, reserved_bytes = self._lock_state(cursor)
+                writes, reads, egress = self._lock_month(cursor, period)
+            connection.commit()
+        return ArtifactStorageUsage(
+            period_start=period,
+            active_bytes=active_bytes,
+            reserved_bytes=reserved_bytes,
+            write_requests=writes,
+            read_requests=reads,
+            egress_bytes=egress,
+        )
+
+
+def build_artifact_storage_repository(database_url: str | None) -> ArtifactStorageRepository:
+    if database_url:
+        return PostgresArtifactStorageRepository(database_url)
+    return InMemoryArtifactStorageRepository()

--- a/nzeroesg-api/persistence/migrations/006_artifact_object_storage.sql
+++ b/nzeroesg-api/persistence/migrations/006_artifact_object_storage.sql
@@ -1,0 +1,54 @@
+CREATE TABLE artifact_objects (
+    artifact_id UUID PRIMARY KEY,
+    workspace_id VARCHAR(80) NOT NULL,
+    provider VARCHAR(30) NOT NULL,
+    bucket VARCHAR(255) NOT NULL,
+    object_key VARCHAR(1024) NOT NULL UNIQUE,
+    size_bytes BIGINT NOT NULL,
+    content_sha256 CHAR(64) NOT NULL,
+    media_type VARCHAR(100) NOT NULL,
+    status VARCHAR(30) NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    etag VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    stored_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ,
+    CONSTRAINT artifact_objects_provider CHECK (provider = 'aws_s3'),
+    CONSTRAINT artifact_objects_status CHECK (
+        status IN ('reserved', 'ready', 'delete_pending', 'deleted', 'failed')
+    ),
+    CONSTRAINT artifact_objects_size_positive CHECK (size_bytes > 0)
+);
+
+CREATE INDEX artifact_objects_workspace_status_idx
+    ON artifact_objects (workspace_id, status, expires_at);
+
+CREATE INDEX artifact_objects_cleanup_idx
+    ON artifact_objects (status, expires_at)
+    WHERE status IN ('ready', 'delete_pending');
+
+CREATE TABLE artifact_storage_state (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE,
+    active_bytes BIGINT NOT NULL DEFAULT 0,
+    reserved_bytes BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT artifact_storage_state_singleton CHECK (singleton),
+    CONSTRAINT artifact_storage_active_nonnegative CHECK (active_bytes >= 0),
+    CONSTRAINT artifact_storage_reserved_nonnegative CHECK (reserved_bytes >= 0)
+);
+
+INSERT INTO artifact_storage_state (singleton) VALUES (TRUE);
+
+CREATE TABLE artifact_storage_monthly_usage (
+    period_start DATE PRIMARY KEY,
+    write_requests BIGINT NOT NULL DEFAULT 0,
+    read_requests BIGINT NOT NULL DEFAULT 0,
+    egress_bytes BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT artifact_storage_period_is_month_start CHECK (
+        period_start = date_trunc('month', period_start)::date
+    ),
+    CONSTRAINT artifact_storage_writes_nonnegative CHECK (write_requests >= 0),
+    CONSTRAINT artifact_storage_reads_nonnegative CHECK (read_requests >= 0),
+    CONSTRAINT artifact_storage_egress_nonnegative CHECK (egress_bytes >= 0)
+);

--- a/nzeroesg-api/requirements.txt
+++ b/nzeroesg-api/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.12
+boto3==1.43.54
 geopy==2.4.1
 langchain==0.3.26
 langchain-openai==0.3.21

--- a/nzeroesg-api/services/__init__.py
+++ b/nzeroesg-api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application services coordinating domain, persistence, and providers."""

--- a/nzeroesg-api/services/artifact_storage.py
+++ b/nzeroesg-api/services/artifact_storage.py
@@ -141,10 +141,18 @@ class ArtifactStorageService:
             )
         return source, content
 
-    def schedule_delete(self, workspace_id: str, artifact_id: str) -> bool:
+    def schedule_delete(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> bool:
         if not self.enabled:
             return True
-        source = self.repository.get_ready(workspace_id, artifact_id)
+        timestamp = now or datetime.now(UTC)
+        self.sweep_expired(now=timestamp)
+        source = self.repository.get_ready(workspace_id, artifact_id, now=timestamp)
         if source is None:
             return True
         self.repository.mark_delete_pending(workspace_id, artifact_id)
@@ -152,7 +160,7 @@ class ArtifactStorageService:
             self.object_store.delete(source.object_key)
         except ArtifactStorageProviderError:
             return False
-        self.repository.mark_deleted(workspace_id, artifact_id)
+        self.repository.mark_deleted(workspace_id, artifact_id, now=timestamp)
         return True
 
     def sweep_expired(

--- a/nzeroesg-api/services/artifact_storage.py
+++ b/nzeroesg-api/services/artifact_storage.py
@@ -1,0 +1,183 @@
+"""Application service for bounded 24-hour artifact source retention."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+
+from domain.artifacts.models import Artifact
+from domain.artifacts.storage import (
+    ArtifactObject,
+    ArtifactObjectStatus,
+    ArtifactStorageNotFoundError,
+    ArtifactStoragePolicy,
+    ArtifactStorageProviderError,
+    ArtifactStorageUsage,
+    SourceRetention,
+)
+from integrations.aws_s3 import ObjectStore
+from persistence.artifact_storage import ArtifactStorageRepository
+
+
+class ArtifactStorageService:
+    """Coordinates durable budget reservations with S3 operations."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        repository: ArtifactStorageRepository,
+        policy: ArtifactStoragePolicy,
+        object_store: ObjectStore | None = None,
+        bucket: str = "",
+        provider: str = "aws_s3",
+    ) -> None:
+        if enabled and object_store is None:
+            raise ValueError("An object store is required when artifact storage is enabled.")
+        if enabled and not bucket:
+            raise ValueError("A bucket is required when artifact storage is enabled.")
+        self.enabled = enabled
+        self.repository = repository
+        self.policy = policy
+        self.object_store = object_store
+        self.bucket = bucket
+        self.provider = provider
+
+    def retain(
+        self,
+        artifact: Artifact,
+        content: bytes,
+        *,
+        workspace_expires_at: int,
+        now: datetime | None = None,
+    ) -> SourceRetention:
+        if not self.enabled:
+            return SourceRetention(status="ephemeral")
+        if not content:
+            raise ValueError("Empty artifact sources cannot be retained.")
+
+        timestamp = now or datetime.now(UTC)
+        retention_expiry = timestamp + timedelta(hours=self.policy.retention_hours)
+        workspace_expiry = datetime.fromtimestamp(workspace_expires_at, UTC)
+        expires_at = min(retention_expiry, workspace_expiry)
+        if expires_at <= timestamp:
+            raise ArtifactStorageNotFoundError(artifact.artifact_id)
+
+        self.sweep_expired(now=timestamp)
+        digest = sha256(content).hexdigest()
+        if artifact.content_sha256 != digest:
+            raise ValueError("Artifact source hash does not match its catalog record.")
+        object_key = (
+            f"workspaces/{artifact.workspace_id}/artifacts/{artifact.artifact_id}/"
+            f"v{artifact.version}/{digest}"
+        )
+        source = ArtifactObject(
+            artifact_id=artifact.artifact_id,
+            workspace_id=artifact.workspace_id,
+            provider=self.provider,
+            bucket=self.bucket,
+            object_key=object_key,
+            size_bytes=len(content),
+            content_sha256=digest,
+            media_type=artifact.media_type or "application/octet-stream",
+            status=ArtifactObjectStatus.RESERVED,
+            expires_at=expires_at,
+            created_at=timestamp,
+        )
+        self.repository.reserve_upload(source, self.policy, now=timestamp)
+        try:
+            etag = self.object_store.put(
+                object_key,
+                content,
+                media_type=source.media_type,
+                content_sha256=digest,
+            )
+            stored = self.repository.mark_stored(
+                artifact.workspace_id,
+                artifact.artifact_id,
+                etag,
+                now=timestamp,
+            )
+        except Exception:
+            try:
+                self.object_store.delete(object_key)
+            except ArtifactStorageProviderError:
+                pass
+            self.repository.mark_upload_failed(
+                artifact.workspace_id,
+                artifact.artifact_id,
+                now=timestamp,
+            )
+            raise
+        return SourceRetention(
+            status="retained",
+            size_bytes=stored.size_bytes,
+            expires_at=stored.expires_at,
+        )
+
+    def download(
+        self,
+        workspace_id: str,
+        artifact_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> tuple[ArtifactObject, bytes]:
+        if not self.enabled:
+            raise ArtifactStorageNotFoundError(artifact_id)
+        timestamp = now or datetime.now(UTC)
+        source = self.repository.reserve_download(
+            workspace_id,
+            artifact_id,
+            self.policy,
+            now=timestamp,
+        )
+        content = self.object_store.get(source.object_key)
+        if (
+            len(content) != source.size_bytes
+            or sha256(content).hexdigest() != source.content_sha256
+        ):
+            raise ArtifactStorageProviderError(
+                "Stored artifact source failed integrity validation."
+            )
+        return source, content
+
+    def schedule_delete(self, workspace_id: str, artifact_id: str) -> bool:
+        if not self.enabled:
+            return True
+        source = self.repository.get_ready(workspace_id, artifact_id)
+        if source is None:
+            return True
+        self.repository.mark_delete_pending(workspace_id, artifact_id)
+        try:
+            self.object_store.delete(source.object_key)
+        except ArtifactStorageProviderError:
+            return False
+        self.repository.mark_deleted(workspace_id, artifact_id)
+        return True
+
+    def sweep_expired(
+        self,
+        *,
+        now: datetime | None = None,
+        limit: int = 100,
+    ) -> int:
+        if not self.enabled:
+            return 0
+        timestamp = now or datetime.now(UTC)
+        deleted = 0
+        for source in self.repository.cleanup_candidates(now=timestamp, limit=limit):
+            try:
+                self.object_store.delete(source.object_key)
+            except ArtifactStorageProviderError:
+                self.repository.mark_delete_pending(source.workspace_id, source.artifact_id)
+                continue
+            self.repository.mark_deleted(
+                source.workspace_id,
+                source.artifact_id,
+                now=timestamp,
+            )
+            deleted += 1
+        return deleted
+
+    def usage(self, *, now: datetime | None = None) -> ArtifactStorageUsage:
+        return self.repository.usage(now=now)

--- a/nzeroesg-api/tests/test_api.py
+++ b/nzeroesg-api/tests/test_api.py
@@ -56,6 +56,7 @@ def test_health_is_available_without_provider_credentials():
         "environment": "development",
         "assistant_enabled": False,
         "semantic_search_enabled": False,
+        "artifact_storage_enabled": False,
     }
     assert response.headers["x-content-type-options"] == "nosniff"
     assert response.headers["x-frame-options"] == "DENY"

--- a/nzeroesg-api/tests/test_artifact_storage.py
+++ b/nzeroesg-api/tests/test_artifact_storage.py
@@ -1,0 +1,330 @@
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from hashlib import sha256
+from io import BytesIO
+
+import pytest
+
+from domain.artifacts.models import ArtifactKind, ArtifactSourceType, create_artifact
+from domain.artifacts.storage import (
+    ArtifactObject,
+    ArtifactObjectStatus,
+    ArtifactStorageBudgetExceededError,
+    ArtifactStorageNotFoundError,
+    ArtifactStoragePolicy,
+)
+from integrations.aws_s3 import InMemoryObjectStore, S3ObjectStore
+from persistence.artifact_storage import (
+    InMemoryArtifactStorageRepository,
+    PostgresArtifactStorageRepository,
+)
+from persistence.workspaces import build_workspace_repository
+from services.artifact_storage import ArtifactStorageService
+
+
+def artifact_for(content: bytes, *, workspace_id: str = "demo-storage"):
+    return create_artifact(
+        workspace_id=workspace_id,
+        kind=ArtifactKind.EVIDENCE_DOCUMENT,
+        title="evidence.txt",
+        source_type=ArtifactSourceType.LOCAL_UPLOAD,
+        created_by="test",
+        media_type="text/plain",
+        content_sha256=sha256(content).hexdigest(),
+    )
+
+
+def service_for(policy: ArtifactStoragePolicy | None = None):
+    repository = InMemoryArtifactStorageRepository()
+    object_store = InMemoryObjectStore()
+    service = ArtifactStorageService(
+        enabled=True,
+        repository=repository,
+        policy=policy or ArtifactStoragePolicy(),
+        object_store=object_store,
+        bucket="carbonsage-test",
+    )
+    return service, repository, object_store
+
+
+def test_default_policy_leaves_margin_below_fifty_cent_s3_ceiling():
+    policy = ArtifactStoragePolicy()
+
+    assert policy.estimated_maximum_monthly_cost_usd() == Decimal("0.3790")
+    assert policy.estimated_maximum_monthly_cost_usd() < policy.billing_ceiling_usd
+
+
+def test_policy_rejects_limits_that_cross_the_approved_cost_ceiling():
+    with pytest.raises(ValueError, match="billing ceiling"):
+        ArtifactStoragePolicy(max_egress_bytes_per_month=4_000_000_000)
+
+
+def test_service_retains_validates_downloads_and_deletes_private_source():
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    content = b"Supplier evidence"
+    artifact = artifact_for(content)
+    service, repository, object_store = service_for()
+
+    retention = service.retain(
+        artifact,
+        content,
+        workspace_expires_at=int((now + timedelta(hours=24)).timestamp()),
+        now=now,
+    )
+
+    assert retention.status == "retained"
+    assert retention.size_bytes == len(content)
+    assert retention.expires_at == now + timedelta(hours=24)
+    source, downloaded = service.download(
+        artifact.workspace_id,
+        artifact.artifact_id,
+        now=now,
+    )
+    assert downloaded == content
+    assert source.object_key.startswith(
+        f"workspaces/{artifact.workspace_id}/artifacts/{artifact.artifact_id}/v1/"
+    )
+    assert object_store.objects[source.object_key] == content
+
+    assert service.schedule_delete(artifact.workspace_id, artifact.artifact_id)
+    assert source.object_key not in object_store.objects
+    assert repository.usage(now=now).active_bytes == 0
+    with pytest.raises(ArtifactStorageNotFoundError):
+        service.download(artifact.workspace_id, artifact.artifact_id, now=now)
+
+
+def test_service_uses_workspace_expiry_when_it_is_earlier_than_24_hours():
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    content = b"short workspace"
+    artifact = artifact_for(content)
+    service, _, _ = service_for()
+
+    retention = service.retain(
+        artifact,
+        content,
+        workspace_expires_at=int((now + timedelta(hours=2)).timestamp()),
+        now=now,
+    )
+
+    assert retention.expires_at == now + timedelta(hours=2)
+
+
+def test_expired_objects_are_swept_and_release_active_storage():
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    content = b"expires"
+    artifact = artifact_for(content)
+    policy = ArtifactStoragePolicy(retention_hours=1)
+    service, repository, object_store = service_for(policy)
+    service.retain(
+        artifact,
+        content,
+        workspace_expires_at=int((now + timedelta(hours=24)).timestamp()),
+        now=now,
+    )
+
+    assert service.sweep_expired(now=now + timedelta(hours=1)) == 1
+    assert object_store.objects == {}
+    assert repository.usage(now=now).active_bytes == 0
+
+
+def test_repository_blocks_storage_write_read_and_egress_overages_before_provider_calls():
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    content = b"12345"
+    storage_policy = ArtifactStoragePolicy(
+        max_active_storage_bytes=5,
+        max_workspace_storage_bytes=5,
+        max_write_requests_per_month=1,
+        max_read_requests_per_month=1,
+        max_egress_bytes_per_month=5,
+    )
+    service, repository, _ = service_for(storage_policy)
+    first = artifact_for(content)
+    service.retain(
+        first,
+        content,
+        workspace_expires_at=int((now + timedelta(hours=24)).timestamp()),
+        now=now,
+    )
+
+    second = artifact_for(content, workspace_id="demo-other")
+    with pytest.raises(ArtifactStorageBudgetExceededError, match="active storage"):
+        service.retain(
+            second,
+            content,
+            workspace_expires_at=int((now + timedelta(hours=24)).timestamp()),
+            now=now,
+        )
+
+    assert service.download(first.workspace_id, first.artifact_id, now=now)[1] == content
+    with pytest.raises(ArtifactStorageBudgetExceededError, match="read request"):
+        service.download(first.workspace_id, first.artifact_id, now=now)
+    usage = repository.usage(now=now)
+    assert usage.active_bytes == 5
+    assert usage.write_requests == 1
+    assert usage.read_requests == 1
+    assert usage.egress_bytes == 5
+
+    assert service.schedule_delete(first.workspace_id, first.artifact_id)
+    with pytest.raises(ArtifactStorageBudgetExceededError, match="write request"):
+        service.retain(
+            second,
+            content,
+            workspace_expires_at=int((now + timedelta(hours=24)).timestamp()),
+            now=now,
+        )
+
+
+def test_egress_is_reserved_before_a_second_download():
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    content = b"12345"
+    policy = ArtifactStoragePolicy(
+        max_active_storage_bytes=10,
+        max_workspace_storage_bytes=10,
+        max_read_requests_per_month=2,
+        max_egress_bytes_per_month=5,
+    )
+    service, repository, _ = service_for(policy)
+    artifact = artifact_for(content)
+    service.retain(
+        artifact,
+        content,
+        workspace_expires_at=int((now + timedelta(hours=24)).timestamp()),
+        now=now,
+    )
+
+    assert service.download(artifact.workspace_id, artifact.artifact_id, now=now)[1] == content
+    with pytest.raises(ArtifactStorageBudgetExceededError, match="egress"):
+        service.download(artifact.workspace_id, artifact.artifact_id, now=now)
+    usage = repository.usage(now=now)
+    assert usage.read_requests == 1
+    assert usage.egress_bytes == 5
+
+
+def test_workspace_storage_limit_is_enforced_before_a_second_upload():
+    now = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    content = b"12345"
+    policy = ArtifactStoragePolicy(
+        max_active_storage_bytes=20,
+        max_workspace_storage_bytes=5,
+    )
+    service, repository, object_store = service_for(policy)
+    first = artifact_for(content)
+    second = artifact_for(content, workspace_id=first.workspace_id)
+    service.retain(
+        first,
+        content,
+        workspace_expires_at=int((now + timedelta(hours=24)).timestamp()),
+        now=now,
+    )
+
+    with pytest.raises(ArtifactStorageBudgetExceededError, match="workspace storage"):
+        service.retain(
+            second,
+            content,
+            workspace_expires_at=int((now + timedelta(hours=24)).timestamp()),
+            now=now,
+        )
+
+    assert repository.usage(now=now).active_bytes == len(content)
+    assert len(object_store.objects) == 1
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.put_args = None
+        self.get_args = None
+        self.delete_args = None
+
+    def put_object(self, **kwargs):
+        self.put_args = kwargs
+        return {"ETag": '"etag"'}
+
+    def get_object(self, **kwargs):
+        self.get_args = kwargs
+        return {"Body": BytesIO(b"content")}
+
+    def delete_object(self, **kwargs):
+        self.delete_args = kwargs
+
+
+def test_s3_adapter_uses_private_sse_s3_operations_on_one_bucket():
+    client = FakeS3Client()
+    store = S3ObjectStore(
+        bucket="carbonsage-artifacts",
+        region="ca-central-1",
+        client=client,
+    )
+
+    etag = store.put(
+        "workspaces/demo/artifacts/id/v1/hash",
+        b"content",
+        media_type="text/plain",
+        content_sha256="a" * 64,
+    )
+    downloaded = store.get("workspaces/demo/artifacts/id/v1/hash")
+    store.delete("workspaces/demo/artifacts/id/v1/hash")
+
+    assert etag == '"etag"'
+    assert downloaded == b"content"
+    assert client.put_args == {
+        "Bucket": "carbonsage-artifacts",
+        "Key": "workspaces/demo/artifacts/id/v1/hash",
+        "Body": b"content",
+        "ContentLength": 7,
+        "ContentType": "text/plain",
+        "Metadata": {"content-sha256": "a" * 64},
+        "ServerSideEncryption": "AES256",
+    }
+    assert client.get_args == {
+        "Bucket": "carbonsage-artifacts",
+        "Key": "workspaces/demo/artifacts/id/v1/hash",
+    }
+    assert client.delete_args == {
+        "Bucket": "carbonsage-artifacts",
+        "Key": "workspaces/demo/artifacts/id/v1/hash",
+    }
+
+
+@pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="DATABASE_URL is not configured")
+def test_postgres_breaker_reservations_are_durable_and_release_active_bytes():
+    database_url = os.environ["DATABASE_URL"]
+    build_workspace_repository(database_url)  # Applies checked-in migrations.
+    repository = PostgresArtifactStorageRepository(database_url)
+    now = datetime.now(UTC)
+    content = b"postgres storage ledger"
+    artifact = artifact_for(content, workspace_id="demo-postgres-storage")
+    source = ArtifactObject(
+        artifact_id=artifact.artifact_id,
+        workspace_id=artifact.workspace_id,
+        provider="aws_s3",
+        bucket="carbonsage-test",
+        object_key=f"workspaces/{artifact.workspace_id}/{artifact.artifact_id}",
+        size_bytes=len(content),
+        content_sha256=artifact.content_sha256 or "",
+        media_type="text/plain",
+        status=ArtifactObjectStatus.RESERVED,
+        expires_at=now + timedelta(hours=24),
+        created_at=now,
+    )
+    before = repository.usage(now=now)
+
+    repository.reserve_upload(source, ArtifactStoragePolicy(), now=now)
+    repository.mark_stored(source.workspace_id, source.artifact_id, '"etag"', now=now)
+    reserved_download = repository.reserve_download(
+        source.workspace_id,
+        source.artifact_id,
+        ArtifactStoragePolicy(),
+        now=now,
+    )
+    during = repository.usage(now=now)
+
+    assert reserved_download.content_sha256 == source.content_sha256
+    assert during.active_bytes == before.active_bytes + len(content)
+    assert during.reserved_bytes == before.reserved_bytes
+    assert during.write_requests == before.write_requests + 1
+    assert during.read_requests == before.read_requests + 1
+    assert during.egress_bytes == before.egress_bytes + len(content)
+
+    repository.mark_deleted(source.workspace_id, source.artifact_id, now=now)
+    assert repository.usage(now=now).active_bytes == before.active_bytes

--- a/nzeroesg-api/tests/test_artifact_storage.py
+++ b/nzeroesg-api/tests/test_artifact_storage.py
@@ -87,7 +87,11 @@ def test_service_retains_validates_downloads_and_deletes_private_source():
     )
     assert object_store.objects[source.object_key] == content
 
-    assert service.schedule_delete(artifact.workspace_id, artifact.artifact_id)
+    assert service.schedule_delete(
+        artifact.workspace_id,
+        artifact.artifact_id,
+        now=now,
+    )
     assert source.object_key not in object_store.objects
     assert repository.usage(now=now).active_bytes == 0
     with pytest.raises(ArtifactStorageNotFoundError):
@@ -165,7 +169,11 @@ def test_repository_blocks_storage_write_read_and_egress_overages_before_provide
     assert usage.read_requests == 1
     assert usage.egress_bytes == 5
 
-    assert service.schedule_delete(first.workspace_id, first.artifact_id)
+    assert service.schedule_delete(
+        first.workspace_id,
+        first.artifact_id,
+        now=now,
+    )
     with pytest.raises(ArtifactStorageBudgetExceededError, match="write request"):
         service.retain(
             second,

--- a/nzeroesg-api/tests/test_artifacts.py
+++ b/nzeroesg-api/tests/test_artifacts.py
@@ -1,8 +1,13 @@
 from fastapi.testclient import TestClient
 
+import api.artifacts as artifacts_api
+from domain.artifacts.storage import ArtifactStoragePolicy
 from domain.workspaces.principals import AuthenticationMethod, WorkspacePrincipal
 from domain.workspaces.sessions import WorkspaceSession
+from integrations.aws_s3 import InMemoryObjectStore
 from main import app
+from persistence.artifact_storage import InMemoryArtifactStorageRepository
+from services.artifact_storage import ArtifactStorageService
 
 SHIPMENT_CSV = (
     b"shipment_id,origin,destination,weight_value,weight_unit,distance_value,"
@@ -48,6 +53,7 @@ def test_shipment_artifact_crud_is_workspace_scoped_and_deletion_hides_data():
     assert artifact["status"] == "ready"
     assert artifact["source_type"] == "local_upload"
     assert artifact["metadata"]["accepted_rows"] == 1
+    assert artifact["metadata"]["source_retention"]["status"] == "ephemeral"
 
     listed = owner.get("/artifacts")
     assert listed.status_code == 200
@@ -68,6 +74,38 @@ def test_shipment_artifact_crud_is_workspace_scoped_and_deletion_hides_data():
     assert owner.get(f"/artifacts/{artifact_id}").status_code == 404
     assert owner.get("/artifacts").json()["artifacts"] == []
     assert owner.get("/shipments").json()["accepted_rows"] == 0
+
+
+def test_retained_shipment_source_is_private_downloadable_and_deleted(monkeypatch):
+    storage = ArtifactStorageService(
+        enabled=True,
+        repository=InMemoryArtifactStorageRepository(),
+        policy=ArtifactStoragePolicy(),
+        object_store=InMemoryObjectStore(),
+        bucket="carbonsage-test",
+    )
+    monkeypatch.setattr(artifacts_api, "artifact_storage_service", storage)
+    owner = authenticated_client()
+    other = authenticated_client()
+
+    uploaded = upload_shipments(owner)
+
+    assert uploaded.status_code == 200
+    artifact = uploaded.json()["artifact"]
+    artifact_id = artifact["artifact_id"]
+    assert artifact["metadata"]["source_retention"]["status"] == "retained"
+    assert artifact["metadata"]["source_retention"]["size_bytes"] == len(SHIPMENT_CSV)
+    assert other.get(f"/artifacts/{artifact_id}/content").status_code == 404
+
+    downloaded = owner.get(f"/artifacts/{artifact_id}/content")
+    assert downloaded.status_code == 200
+    assert downloaded.content == SHIPMENT_CSV
+    assert downloaded.headers["content-type"] == "text/csv; charset=utf-8"
+    assert downloaded.headers["cache-control"] == "private, no-store"
+    assert downloaded.headers["x-content-sha256"] == artifact["content_sha256"]
+
+    assert owner.delete(f"/artifacts/{artifact_id}").status_code == 204
+    assert owner.get(f"/artifacts/{artifact_id}/content").status_code == 404
 
 
 def test_evidence_artifact_identity_flows_to_citations_and_delete_hides_evidence():

--- a/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
+++ b/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
@@ -49,6 +49,30 @@ type ArtifactCatalogProps = {
   onDeleted: (kind: ArtifactKind) => void | Promise<void>;
 };
 
+type SourceRetention = {
+  status: "retained" | "ephemeral";
+  size_bytes: number | null;
+  expires_at: string | null;
+};
+
+function sourceRetentionFor(artifact: Artifact): SourceRetention | null {
+  const value = artifact.metadata.source_retention;
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.status !== "retained" && candidate.status !== "ephemeral") {
+    return null;
+  }
+  return {
+    status: candidate.status,
+    size_bytes:
+      typeof candidate.size_bytes === "number" ? candidate.size_bytes : null,
+    expires_at:
+      typeof candidate.expires_at === "string" ? candidate.expires_at : null,
+  };
+}
+
 export default function ArtifactCatalog({
   refreshToken,
   onDeleted,
@@ -161,6 +185,41 @@ export default function ArtifactCatalog({
     }
   }
 
+  async function downloadArtifact(artifact: Artifact) {
+    setBusyId(artifact.artifact_id);
+    setError(null);
+    try {
+      const response = await fetch(
+        `${getBackendUrl()}/artifacts/${artifact.artifact_id}/content`,
+        { credentials: "include" },
+      );
+      if (!response.ok) {
+        throw new Error(
+          response.status === 404
+            ? "The retained source has expired."
+            : "The retained source could not be downloaded.",
+        );
+      }
+      const objectUrl = URL.createObjectURL(await response.blob());
+      const link = document.createElement("a");
+      link.href = objectUrl;
+      link.download = artifact.title;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(objectUrl);
+      setStatusMessage(`Downloaded retained source for ${artifact.title}.`);
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "The retained source could not be downloaded.",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  }
+
   return (
     <section
       id="artifacts"
@@ -174,8 +233,8 @@ export default function ArtifactCatalog({
       </h2>
       <p className="mt-2 max-w-3xl leading-7 text-muted-foreground">
         Track the source, status, and provenance of uploaded datasets, supplier
-        evidence, and saved decision reports. Raw files are not retained beyond
-        bounded ingestion.
+        evidence, and saved decision reports. Supported upload sources are kept
+        private for at most 24 hours, then removed automatically.
       </p>
 
       {error ? (
@@ -194,125 +253,153 @@ export default function ArtifactCatalog({
         </p>
       ) : (
         <div className="mt-5 grid gap-4 xl:grid-cols-2">
-          {artifacts.map((artifact) => (
-            <article
-              key={artifact.artifact_id}
-              className="min-w-0 rounded-lg border border-border bg-background p-4"
-            >
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-accent">
-                    {kindLabels[artifact.kind]}
-                  </p>
-                  <h3 className="mt-1 break-words font-semibold text-primary">
-                    {artifact.title}
-                  </h3>
+          {artifacts.map((artifact) => {
+            const sourceRetention = sourceRetentionFor(artifact);
+            return (
+              <article
+                key={artifact.artifact_id}
+                className="min-w-0 rounded-lg border border-border bg-background p-4"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-accent">
+                      {kindLabels[artifact.kind]}
+                    </p>
+                    <h3 className="mt-1 break-words font-semibold text-primary">
+                      {artifact.title}
+                    </h3>
+                  </div>
+                  <span className="rounded-full bg-secondary/10 px-2 py-1 text-xs font-semibold capitalize text-primary">
+                    {artifact.status}
+                  </span>
                 </div>
-                <span className="rounded-full bg-secondary/10 px-2 py-1 text-xs font-semibold capitalize text-primary">
-                  {artifact.status}
-                </span>
-              </div>
 
-              <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
-                <div>
-                  <dt className="text-xs text-muted-foreground">Source</dt>
-                  <dd className="break-words text-primary">
-                    {sourceLabels[artifact.source_type]}
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-muted-foreground">Created</dt>
-                  <dd className="text-primary">
-                    {new Intl.DateTimeFormat(undefined, {
-                      dateStyle: "medium",
-                      timeStyle: "short",
-                    }).format(new Date(artifact.created_at))}
-                  </dd>
-                </div>
-              </dl>
-
-              <details className="mt-4 text-sm text-muted-foreground">
-                <summary className="cursor-pointer font-semibold text-primary">
-                  Inspect provenance
-                </summary>
-                <dl className="mt-3 space-y-2">
+                <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
                   <div>
-                    <dt className="text-xs">Artifact ID</dt>
-                    <dd className="break-all font-mono text-xs">
-                      {artifact.artifact_id}
+                    <dt className="text-xs text-muted-foreground">Source</dt>
+                    <dd className="break-words text-primary">
+                      {sourceLabels[artifact.source_type]}
                     </dd>
                   </div>
                   <div>
-                    <dt className="text-xs">Source reference</dt>
-                    <dd className="break-words">
-                      {artifact.source_reference ?? "Generated in workspace"}
+                    <dt className="text-xs text-muted-foreground">Created</dt>
+                    <dd className="text-primary">
+                      {new Intl.DateTimeFormat(undefined, {
+                        dateStyle: "medium",
+                        timeStyle: "short",
+                      }).format(new Date(artifact.created_at))}
                     </dd>
-                  </div>
-                  <div>
-                    <dt className="text-xs">Content identity</dt>
-                    <dd className="break-all font-mono text-xs">
-                      {artifact.content_sha256 ?? "No source hash"}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-xs">Version</dt>
-                    <dd>{artifact.version}</dd>
                   </div>
                 </dl>
-              </details>
 
-              {editingId === artifact.artifact_id ? (
-                <div className="mt-4 flex flex-wrap items-end gap-2">
-                  <label className="flex min-w-0 flex-1 flex-col gap-1 text-sm font-semibold text-primary">
-                    Artifact title
-                    <input
-                      value={draftTitle}
-                      onChange={(event) => setDraftTitle(event.target.value)}
-                      maxLength={255}
-                      className="min-w-0 rounded-lg border border-border bg-muted px-3 py-2 font-normal"
-                    />
-                  </label>
-                  <button
-                    type="button"
-                    onClick={() => renameArtifact(artifact)}
-                    disabled={busyId === artifact.artifact_id}
-                    className="rounded-full bg-secondary px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
-                  >
-                    Save name
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setEditingId(null)}
-                    className="rounded-full border border-border px-4 py-2 text-sm font-semibold text-primary"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              ) : (
-                <div className="mt-4 flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingId(artifact.artifact_id);
-                      setDraftTitle(artifact.title);
-                      setError(null);
-                    }}
-                    className="rounded-full border border-secondary px-4 py-2 text-sm font-semibold text-secondary"
-                  >
-                    Rename {artifact.title}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => deleteArtifact(artifact)}
-                    disabled={busyId === artifact.artifact_id}
-                    className="rounded-full border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 disabled:opacity-60"
-                  >
-                    Delete {artifact.title}
-                  </button>
-                </div>
-              )}
-            </article>
-          ))}
+                <details className="mt-4 text-sm text-muted-foreground">
+                  <summary className="cursor-pointer font-semibold text-primary">
+                    Inspect provenance
+                  </summary>
+                  <dl className="mt-3 space-y-2">
+                    <div>
+                      <dt className="text-xs">Artifact ID</dt>
+                      <dd className="break-all font-mono text-xs">
+                        {artifact.artifact_id}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs">Source reference</dt>
+                      <dd className="break-words">
+                        {artifact.source_reference ?? "Generated in workspace"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs">Content identity</dt>
+                      <dd className="break-all font-mono text-xs">
+                        {artifact.content_sha256 ?? "No source hash"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs">Version</dt>
+                      <dd>{artifact.version}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs">Source retention</dt>
+                      <dd>
+                        {sourceRetention?.status === "retained" &&
+                        sourceRetention.expires_at
+                          ? `Private until ${new Intl.DateTimeFormat(
+                              undefined,
+                              {
+                                dateStyle: "medium",
+                                timeStyle: "short",
+                              },
+                            ).format(new Date(sourceRetention.expires_at))}`
+                          : "Not retained in this environment"}
+                      </dd>
+                    </div>
+                  </dl>
+                </details>
+
+                {editingId === artifact.artifact_id ? (
+                  <div className="mt-4 flex flex-wrap items-end gap-2">
+                    <label className="flex min-w-0 flex-1 flex-col gap-1 text-sm font-semibold text-primary">
+                      Artifact title
+                      <input
+                        value={draftTitle}
+                        onChange={(event) => setDraftTitle(event.target.value)}
+                        maxLength={255}
+                        className="min-w-0 rounded-lg border border-border bg-muted px-3 py-2 font-normal"
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => renameArtifact(artifact)}
+                      disabled={busyId === artifact.artifact_id}
+                      className="rounded-full bg-secondary px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                    >
+                      Save name
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditingId(null)}
+                      className="rounded-full border border-border px-4 py-2 text-sm font-semibold text-primary"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {sourceRetention?.status === "retained" ? (
+                      <button
+                        type="button"
+                        onClick={() => downloadArtifact(artifact)}
+                        disabled={busyId === artifact.artifact_id}
+                        className="rounded-full bg-secondary px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                      >
+                        Download source
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingId(artifact.artifact_id);
+                        setDraftTitle(artifact.title);
+                        setError(null);
+                      }}
+                      className="rounded-full border border-secondary px-4 py-2 text-sm font-semibold text-secondary"
+                    >
+                      Rename {artifact.title}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteArtifact(artifact)}
+                      disabled={busyId === artifact.artifact_id}
+                      className="rounded-full border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 disabled:opacity-60"
+                    >
+                      Delete {artifact.title}
+                    </button>
+                  </div>
+                )}
+              </article>
+            );
+          })}
         </div>
       )}
     </section>

--- a/render.yaml
+++ b/render.yaml
@@ -32,3 +32,13 @@ services:
         value: "1536"
       - key: OPENROUTER_API_KEY
         sync: false
+      - key: ARTIFACT_STORAGE_ENABLED
+        sync: false
+      - key: AWS_S3_BUCKET
+        sync: false
+      - key: AWS_S3_REGION
+        value: ca-central-1
+      - key: AWS_ACCESS_KEY_ID
+        sync: false
+      - key: AWS_SECRET_ACCESS_KEY
+        sync: false


### PR DESCRIPTION
Implements private AWS S3 source retention for validated artifacts with a 24-hour maximum, PostgreSQL-backed storage/request/egress breakers, and a conservative USD 0.379 priced envelope below the approved USD 0.50 ceiling. Adds migration 006, API-proxied authenticated downloads, deletion/cleanup handling, CloudFormation infrastructure, Render configuration, tests, roadmap updates, and Decision 001. Local backend, PostgreSQL, client, Docker, formatting, and secret checks passed. Production activation remains gated on creating the AWS resources and adding Render secrets. This PR targets dev only; main is intentionally unchanged.