### PR TITLE
Complete Phase 9 documentation handoff

### DIFF
--- a/docs/carbonsage-ecosystem-vision.md
+++ b/docs/carbonsage-ecosystem-vision.md
@@ -633,27 +633,6 @@ evidence.
 - Does the project need one organization, an advisory model, or separate open
   and commercial entities?
 
-## Resume-ready project experience
-
-This wording describes the implemented project as of August 2026 and avoids
-claiming the deferred marketplace or unfinished agent/embed phases.
-
-**CarbonSage (formerly NZeroESG) – ESG Decision Intelligence & Hybrid-RAG
-Platform | Python, FastAPI, Next.js, TypeScript, PostgreSQL/pgvector,
-LangChain, Docker**
-
-- Built and deployed a modular FastAPI/Next.js platform for Scope 3 freight and
-  supplier-evidence workflows, combining bounded CSV/PDF ingestion,
-  deterministic emissions calculations, scenario comparison,
-  workspace-isolated REST APIs, interactive visualizations, and report export.
-- Implemented cited lexical, semantic, and hybrid RAG over PostgreSQL full-text
-  search and pgvector—replacing an earlier ChromaDB prototype—with
-  provider-aware fallback, versioned embeddings, and a 25-query evaluation in
-  which hybrid retrieval achieved `1.0` recall@5.
-- Designed provenance-bearing artifact and citation contracts linking source
-  datasets, normalized records, evidence chunks, and report snapshots;
-  enforced signed expiring workspaces, cross-tenant isolation, soft deletion,
-  and CI/E2E deployment gates across Neon, Render, and Vercel.
 
 ## Closing perspective
 

--- a/docs/demo-roadmap.md
+++ b/docs/demo-roadmap.md
@@ -749,7 +749,7 @@ Verification:
 - The primary deterministic workflow remains usable when model and embedding
   providers are disabled.
 
-Implementation evidence (in progress 2026-08-10):
+Implementation evidence (completed 2026-08-11):
 
 - Migration `007_typed_agent_runtime.sql` and matching in-memory/PostgreSQL
   repositories enforce three active conversations per workspace, twenty

--- a/nzeroesg-client/package-lock.json
+++ b/nzeroesg-client/package-lock.json
@@ -5758,9 +5758,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,10 @@ The API health endpoint is:
 
 - <https://nzeroesg-api.onrender.com/health>
 
+Production currently follows `main` and presents the deterministic workflow.
+The typed agent and control-plane work described below is complete on `dev` and
+will move to production only after its usability and release gates pass.
+
 The public workflow does not require an LLM. The typed agent reports itself as
 disabled unless a compatible model provider is explicitly configured; artifact
 management, retrieval, calculations, scenarios, and reports remain available.


### PR DESCRIPTION
## What changed

- preserve the ecosystem vision as a product and community strategy document by removing resume-specific copy
- mark the typed agent runtime phase as completed
- clarify that production follows `main` while the completed agent work remains on `dev` pending release validation

## Why

This closes the Phase 9 documentation handoff without implying that the unreleased control-plane agent is already live in production.

## Validation

- `git diff --check`
- scoped documentation diff review
