### PR TITLE
Refine CarbonSage workspace usability

### DIFF
--- a/docs/demo-roadmap.md
+++ b/docs/demo-roadmap.md
@@ -815,6 +815,26 @@ Verification:
 - Every structured block has keyboard and narrow-viewport coverage.
 - Provider failure does not affect artifact management or deterministic tools.
 
+Implementation evidence (completed 2026-08-18):
+
+- The dedicated agent workspace can create, switch, restore, and explicitly
+  close bounded workspace conversations while retaining the compact launcher
+  on every other workspace route.
+- A response-details panel translates persisted evidence status and concise
+  tool events into source coverage, processing time, cited source links, and
+  human-readable recent work without exposing model reasoning or raw internal
+  identifiers.
+- Artifact-reference blocks and cited sources now deep-link to the artifact
+  page, where the matching workspace record is scrolled into view and
+  highlighted.
+- The workspace visual system now uses neutral surfaces, charcoal actions, and
+  restrained sage accents. Placeholder, phase, policy, schema, provider, and
+  synthetic assistant-introduction copy is absent from the primary interface.
+- Eight Playwright flows cover the full deterministic workflow, isolation,
+  deletion, provider-disabled behavior, conversation restoration and controls,
+  structured response details, keyboard operation, and a 390-pixel viewport.
+  TypeScript, ESLint, and the production Next.js build pass locally.
+
 Exit gate:
 
 > The dashboard is a useful agent control plane and test workspace, not the

--- a/docs/langchain.rag.workflow.md
+++ b/docs/langchain.rag.workflow.md
@@ -275,8 +275,9 @@ Built 1 comparison chart
 
 This is tool and retrieval observability, not private chain-of-thought. Stored
 events contain tool names, timings, artifact identifiers, result counts, and
-sanitized errors without raw uploaded content or model reasoning. The full
-dashboard event-inspection treatment remains in Phase 10.
+sanitized errors without raw uploaded content or model reasoning. The workspace
+agent presents these events as concise, human-readable recent work beside
+source coverage, response time, and linked artifacts.
 
 ## Conversation and memory boundary
 

--- a/nzeroesg-client/app/components/chat_ui/AgentDetailsPanel.tsx
+++ b/nzeroesg-client/app/components/chat_ui/AgentDetailsPanel.tsx
@@ -1,0 +1,221 @@
+import Link from "next/link";
+import {
+  CheckCircle2,
+  Clock3,
+  FileText,
+  MinusCircle,
+  Wrench,
+} from "lucide-react";
+
+import type {
+  AgentAvailability,
+  AgentConversation,
+  AgentResponseEnvelope,
+  AgentToolEvent,
+  ArtifactReferenceBlock,
+  CitationBlock,
+} from "@/app/types/chat";
+
+type AgentDetailsPanelProps = {
+  availability: AgentAvailability;
+  conversation: AgentConversation | null;
+  response: AgentResponseEnvelope | null;
+  toolEvents: AgentToolEvent[];
+  className?: string;
+  showTitle?: boolean;
+};
+
+const evidenceLabels: Record<AgentResponseEnvelope["evidence_status"], string> =
+  {
+    supported: "Sources verified",
+    limited: "More evidence needed",
+    not_required: "No source needed",
+  };
+
+const toolLabels: Record<string, string> = {
+  list_workspace_artifacts: "Reviewed workspace files",
+  search_supplier_evidence: "Searched supplier evidence",
+  get_citation_context: "Checked source context",
+  calculate_freight_emissions: "Calculated freight emissions",
+  compare_freight_scenarios: "Compared freight scenarios",
+  summarize_data_quality: "Reviewed data quality",
+  build_decision_report: "Prepared report data",
+};
+
+function readableToolName(name: string) {
+  return (
+    toolLabels[name] ??
+    name
+      .replaceAll("_", " ")
+      .replace(/^./, (character) => character.toUpperCase())
+  );
+}
+
+export default function AgentDetailsPanel({
+  availability,
+  conversation,
+  response,
+  toolEvents,
+  className = "",
+  showTitle = true,
+}: AgentDetailsPanelProps) {
+  const citedSources = response
+    ? response.blocks
+        .filter((block): block is CitationBlock => block.type === "citation")
+        .map((block) => ({
+          artifactId: block.artifact_id,
+          label: block.filename,
+        }))
+    : [];
+  const referencedArtifacts = response
+    ? response.blocks
+        .filter(
+          (block): block is ArtifactReferenceBlock =>
+            block.type === "artifact_reference",
+        )
+        .map((block) => ({
+          artifactId: block.artifact_id,
+          label: block.title,
+        }))
+    : [];
+  const sources = [...citedSources, ...referencedArtifacts].filter(
+    (source, index, all) =>
+      all.findIndex((item) => item.artifactId === source.artifactId) === index,
+  );
+  const recentEvents = toolEvents.slice(-6).reverse();
+
+  return (
+    <aside
+      aria-label="Response details"
+      className={`min-h-0 overflow-y-auto border-t border-border bg-muted/55 p-5 lg:border-l lg:border-t-0 ${className}`}
+    >
+      {showTitle ? (
+        <h3 className="text-sm font-semibold text-primary">Response details</h3>
+      ) : null}
+
+      {availability === "disabled" ? (
+        <p className="mt-3 rounded-xl border border-border bg-background p-3 text-sm leading-6 text-muted-foreground">
+          CarbonSage is not configured in this environment. Files, calculations,
+          scenarios, and reports remain available.
+        </p>
+      ) : availability === "unreachable" ? (
+        <p className="mt-3 rounded-xl border border-border bg-background p-3 text-sm leading-6 text-muted-foreground">
+          CarbonSage could not be reached. Your workspace is still available.
+        </p>
+      ) : null}
+
+      {response ? (
+        <dl className="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-1 xl:grid-cols-2">
+          <div className="rounded-xl border border-border bg-background p-3">
+            <dt className="flex items-center gap-2 text-xs text-muted-foreground">
+              {response.evidence_status === "supported" ? (
+                <CheckCircle2
+                  aria-hidden="true"
+                  className="h-4 w-4 text-accent"
+                />
+              ) : (
+                <MinusCircle aria-hidden="true" className="h-4 w-4" />
+              )}
+              Source coverage
+            </dt>
+            <dd className="mt-2 text-sm font-semibold text-primary">
+              {evidenceLabels[response.evidence_status]}
+            </dd>
+          </div>
+          <div className="rounded-xl border border-border bg-background p-3">
+            <dt className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Clock3 aria-hidden="true" className="h-4 w-4" />
+              Response time
+            </dt>
+            <dd className="mt-2 text-sm font-semibold text-primary">
+              {response.processing_time_ms < 1_000
+                ? `${response.processing_time_ms} ms`
+                : `${(response.processing_time_ms / 1_000).toFixed(1)} s`}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          Source coverage and processing details will appear after a response.
+        </p>
+      )}
+
+      {sources.length ? (
+        <section className="mt-6" aria-labelledby="agent-sources-title">
+          <h4
+            id="agent-sources-title"
+            className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground"
+          >
+            <FileText aria-hidden="true" className="h-4 w-4" />
+            Sources
+          </h4>
+          <ul className="mt-3 space-y-2">
+            {sources.map((source) => (
+              <li key={source.artifactId}>
+                <Link
+                  href={`/dashboard/artifacts?artifact=${encodeURIComponent(source.artifactId)}`}
+                  className="block rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-primary transition hover:border-accent hover:bg-card"
+                >
+                  {source.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className="mt-6" aria-labelledby="agent-work-title">
+        <h4
+          id="agent-work-title"
+          className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground"
+        >
+          <Wrench aria-hidden="true" className="h-4 w-4" />
+          Recent work
+        </h4>
+        {recentEvents.length ? (
+          <ul className="mt-3 space-y-2">
+            {recentEvents.map((event) => (
+              <li
+                key={event.event_id}
+                className="rounded-lg border border-border bg-background px-3 py-2"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <span className="text-sm font-medium text-primary">
+                    {readableToolName(event.tool_name)}
+                  </span>
+                  <span
+                    className={`mt-0.5 h-2 w-2 shrink-0 rounded-full ${
+                      event.status === "succeeded" ? "bg-accent" : "bg-red-500"
+                    }`}
+                    aria-label={event.status}
+                  />
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {event.duration_ms} ms
+                  {event.result_count
+                    ? ` · ${event.result_count} result${event.result_count === 1 ? "" : "s"}`
+                    : ""}
+                </p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            No agent activity in this conversation yet.
+          </p>
+        )}
+      </section>
+
+      {conversation ? (
+        <p className="mt-6 border-t border-border pt-4 text-xs leading-5 text-muted-foreground">
+          Conversation available until{" "}
+          {new Intl.DateTimeFormat(undefined, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          }).format(new Date(conversation.expires_at))}
+          .
+        </p>
+      ) : null}
+    </aside>
+  );
+}

--- a/nzeroesg-client/app/components/chat_ui/ChatInterface.tsx
+++ b/nzeroesg-client/app/components/chat_ui/ChatInterface.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { Leaf, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Leaf, Plus, Trash2, X } from "lucide-react";
 
 import { getBackendUrl } from "@/app/api/urls";
 import type {
+  AgentAvailability,
   AgentConversation,
   AgentHealth,
   ApiError,
@@ -13,6 +14,7 @@ import type {
   MessageExchangeResponse,
   UiMessage,
 } from "@/app/types/chat";
+import AgentDetailsPanel from "./AgentDetailsPanel";
 import ChatInput from "./ChatInput";
 import { LoadingIndicator } from "./LoadingIndicator";
 import StructuredResponse from "./StructuredResponse";
@@ -24,28 +26,22 @@ interface ChatInterfaceProps {
   presentation?: "launcher" | "panel";
 }
 
-type AssistantStatus = "checking" | "available" | "disabled" | "unreachable";
-
-const statusLabels: Record<AssistantStatus, string> = {
+const statusLabels: Record<AgentAvailability, string> = {
   checking: "Checking",
-  available: "Available",
-  disabled: "Disabled",
+  available: "Online",
+  disabled: "Not configured",
   unreachable: "Unavailable",
 };
+
+const suggestedPrompts = [
+  "What files are available in this workspace?",
+  "What data-quality issues should I address?",
+  "Compare the current freight baseline with rail.",
+];
 
 async function apiDetail(response: Response, fallback: string) {
   const payload = (await response.json().catch(() => null)) as ApiError | null;
   return payload?.detail ?? fallback;
-}
-
-function introductionMessage(): UiMessage {
-  return {
-    id: "agent-introduction",
-    content:
-      "Ask CarbonSage to inspect workspace artifacts, retrieve cited supplier evidence, calculate freight emissions, compare scenarios, assess data quality, or build decision-report data. Facts and arithmetic come from validated tools; unsupported evidence questions return a limitation.",
-    role: "assistant",
-    timestamp: new Date(),
-  };
 }
 
 function toUiMessage(message: ConversationDetailResponse["messages"][number]) {
@@ -65,27 +61,69 @@ export default function ChatInterface({
   presentation = "launcher",
 }: ChatInterfaceProps) {
   const isPanel = presentation === "panel";
-  const [messages, setMessages] = useState<UiMessage[]>([
-    introductionMessage(),
-  ]);
+  const [messages, setMessages] = useState<UiMessage[]>([]);
+  const [conversations, setConversations] = useState<AgentConversation[]>([]);
+  const [activeConversation, setActiveConversation] =
+    useState<AgentConversation | null>(null);
+  const [toolEvents, setToolEvents] = useState<
+    ConversationDetailResponse["tool_events"]
+  >([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSwitchingConversation, setIsSwitchingConversation] = useState(false);
   const [isOpen, setIsOpen] = useState(initialOpen || isPanel);
   const [assistantStatus, setAssistantStatus] =
-    useState<AssistantStatus>("checking");
+    useState<AgentAvailability>("checking");
   const [conversationReady, setConversationReady] = useState(false);
+  const [controlError, setControlError] = useState<string | null>(null);
   const conversationId = useRef<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  async function ensureConversation() {
-    if (conversationId.current) return conversationId.current;
+  const applyConversationDetail = useCallback(
+    (detail: ConversationDetailResponse) => {
+      conversationId.current = detail.conversation.conversation_id;
+      setActiveConversation(detail.conversation);
+      setToolEvents(detail.tool_events);
+      setMessages(detail.messages.map(toUiMessage));
+      setConversations((current) =>
+        current.map((conversation) =>
+          conversation.conversation_id === detail.conversation.conversation_id
+            ? detail.conversation
+            : conversation,
+        ),
+      );
+    },
+    [],
+  );
 
+  const loadConversation = useCallback(
+    async (id: string, signal?: AbortSignal) => {
+      const response = await fetch(
+        `${getBackendUrl()}/agent/conversations/${id}`,
+        { credentials: "include", signal },
+      );
+      if (!response.ok) {
+        throw new Error(
+          await apiDetail(
+            response,
+            "Conversation history could not be loaded.",
+          ),
+        );
+      }
+      const detail = (await response.json()) as ConversationDetailResponse;
+      applyConversationDetail(detail);
+      return detail;
+    },
+    [applyConversationDetail],
+  );
+
+  const createConversation = useCallback(async () => {
     const createResponse = await fetch(
       `${getBackendUrl()}/agent/conversations`,
       {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: "CarbonSage workspace decision" }),
+        body: JSON.stringify({ title: `Decision ${conversations.length + 1}` }),
       },
     );
     if (!createResponse.ok) {
@@ -95,7 +133,41 @@ export default function ChatInterface({
     }
     const created = (await createResponse.json()) as AgentConversation;
     conversationId.current = created.conversation_id;
+    setActiveConversation(created);
+    setConversations((current) => [
+      created,
+      ...current.filter(
+        (conversation) =>
+          conversation.conversation_id !== created.conversation_id,
+      ),
+    ]);
+    setMessages([]);
+    setToolEvents([]);
+    setControlError(null);
     return created.conversation_id;
+  }, [conversations.length]);
+
+  async function ensureConversation() {
+    if (conversationId.current) return conversationId.current;
+    return createConversation();
+  }
+
+  async function refreshToolActivity(id: string) {
+    const response = await fetch(
+      `${getBackendUrl()}/agent/conversations/${id}`,
+      { credentials: "include" },
+    );
+    if (!response.ok) return;
+    const detail = (await response.json()) as ConversationDetailResponse;
+    setToolEvents(detail.tool_events);
+    setActiveConversation(detail.conversation);
+    setConversations((current) =>
+      current.map((conversation) =>
+        conversation.conversation_id === detail.conversation.conversation_id
+          ? detail.conversation
+          : conversation,
+      ),
+    );
   }
 
   async function handleSendMessage(content: string) {
@@ -140,6 +212,7 @@ export default function ChatInterface({
           response: assistant.response ?? undefined,
         },
       ]);
+      await refreshToolActivity(activeConversationId);
     } catch (error) {
       setMessages((current) => [
         ...current,
@@ -148,7 +221,7 @@ export default function ChatInterface({
           content:
             error instanceof Error
               ? error.message
-              : "The CarbonSage agent is temporarily unavailable.",
+              : "CarbonSage is temporarily unavailable.",
           role: "assistant",
           timestamp: new Date(),
           isError: true,
@@ -159,6 +232,77 @@ export default function ChatInterface({
     }
   }
 
+  async function handleNewConversation() {
+    setIsSwitchingConversation(true);
+    try {
+      await createConversation();
+    } catch (error) {
+      setControlError(
+        error instanceof Error
+          ? error.message
+          : "A conversation could not be created.",
+      );
+    } finally {
+      setIsSwitchingConversation(false);
+    }
+  }
+
+  async function handleSelectConversation(id: string) {
+    if (!id || id === conversationId.current) return;
+    setIsSwitchingConversation(true);
+    setControlError(null);
+    try {
+      await loadConversation(id);
+    } catch (error) {
+      setControlError(
+        error instanceof Error
+          ? error.message
+          : "Conversation history could not be loaded.",
+      );
+    } finally {
+      setIsSwitchingConversation(false);
+    }
+  }
+
+  async function handleCloseConversation() {
+    const id = conversationId.current;
+    if (!id || !window.confirm("Close this conversation?")) return;
+
+    setIsSwitchingConversation(true);
+    setControlError(null);
+    try {
+      const response = await fetch(
+        `${getBackendUrl()}/agent/conversations/${id}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (!response.ok) {
+        throw new Error(
+          await apiDetail(response, "The conversation could not be closed."),
+        );
+      }
+      const remaining = conversations.filter(
+        (conversation) => conversation.conversation_id !== id,
+      );
+      setConversations(remaining);
+      if (remaining[0]) {
+        await loadConversation(remaining[0].conversation_id);
+      } else {
+        conversationId.current = null;
+        setActiveConversation(null);
+        setMessages([]);
+        setToolEvents([]);
+      }
+    } catch (error) {
+      setControlError(
+        error instanceof Error
+          ? error.message
+          : "The conversation could not be closed.",
+      );
+    } finally {
+      setIsSwitchingConversation(false);
+    }
+  }
+
   function handleToggleChat(newState: boolean) {
     setIsOpen(newState);
     onOpenChange?.(newState);
@@ -166,6 +310,7 @@ export default function ChatInterface({
 
   useEffect(() => {
     const controller = new AbortController();
+
     async function initialize() {
       try {
         const healthResponse = await fetch(`${getBackendUrl()}/agent/health`, {
@@ -174,12 +319,13 @@ export default function ChatInterface({
         });
         if (!healthResponse.ok) throw new Error("Agent health is unavailable.");
         const health = (await healthResponse.json()) as AgentHealth;
-        if (!health.available) {
-          setAssistantStatus("disabled");
-          setConversationReady(true);
-          return;
-        }
+        setAssistantStatus(health.available ? "available" : "disabled");
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") return;
+        setAssistantStatus("unreachable");
+      }
 
+      try {
         const listResponse = await fetch(
           `${getBackendUrl()}/agent/conversations`,
           { credentials: "include", signal: controller.signal },
@@ -191,56 +337,54 @@ export default function ChatInterface({
         }
         const existing =
           (await listResponse.json()) as ConversationListResponse;
-        const current = existing.conversations[0];
-        if (current) {
-          conversationId.current = current.conversation_id;
-          const detailResponse = await fetch(
-            `${getBackendUrl()}/agent/conversations/${current.conversation_id}`,
-            { credentials: "include", signal: controller.signal },
+        setConversations(existing.conversations);
+        if (existing.conversations[0]) {
+          await loadConversation(
+            existing.conversations[0].conversation_id,
+            controller.signal,
           );
-          if (!detailResponse.ok) {
-            throw new Error(
-              await apiDetail(
-                detailResponse,
-                "Conversation history could not be loaded.",
-              ),
-            );
-          }
-          const detail =
-            (await detailResponse.json()) as ConversationDetailResponse;
-          if (detail.messages.length) {
-            setMessages([
-              introductionMessage(),
-              ...detail.messages.map(toUiMessage),
-            ]);
-          }
         }
-        setAssistantStatus("available");
-        setConversationReady(true);
       } catch (error) {
-        if (error instanceof Error && error.name !== "AbortError") {
-          setAssistantStatus("unreachable");
-        }
+        if (error instanceof Error && error.name === "AbortError") return;
+        setControlError(
+          error instanceof Error
+            ? error.message
+            : "Conversations could not be loaded.",
+        );
+      } finally {
+        if (!controller.signal.aborted) setConversationReady(true);
       }
     }
+
     void initialize();
     return () => controller.abort();
-  }, []);
+  }, [loadConversation]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading]);
 
+  const latestResponse = useMemo(
+    () =>
+      [...messages]
+        .reverse()
+        .find((message) => message.role === "assistant" && message.response)
+        ?.response ?? null,
+    [messages],
+  );
   const inputDisabled =
-    isLoading || !conversationReady || assistantStatus !== "available";
+    isLoading ||
+    isSwitchingConversation ||
+    !conversationReady ||
+    assistantStatus !== "available";
   const inputPlaceholder =
     assistantStatus === "checking"
-      ? "Checking agent availability…"
-      : !conversationReady
+      ? "Checking availability…"
+      : !conversationReady || isSwitchingConversation
         ? "Loading conversation…"
         : assistantStatus === "available"
           ? "Ask about this workspace…"
-          : "Agent is not available in this environment";
+          : "CarbonSage is not available in this environment";
 
   return (
     <div>
@@ -251,20 +395,20 @@ export default function ChatInterface({
           aria-labelledby="carbonsage-agent-title"
           className={
             isPanel
-              ? "flex h-[min(48rem,calc(100vh-12rem))] min-h-[38rem] w-full flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-lg"
-              : "fixed inset-x-3 bottom-3 z-50 flex h-[min(46rem,calc(100vh-1.5rem))] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl sm:left-auto sm:right-4 sm:w-[min(48rem,calc(100vw-2rem))]"
+              ? "flex h-[min(50rem,calc(100vh-11rem))] min-h-[38rem] w-full flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm"
+              : "fixed inset-x-3 bottom-3 z-50 flex h-[min(46rem,calc(100vh-1.5rem))] flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl sm:left-auto sm:right-4 sm:w-[min(48rem,calc(100vw-2rem))]"
           }
         >
-          <header className="flex items-start justify-between gap-4 border-b border-border bg-muted px-5 py-4">
+          <header className="flex items-start justify-between gap-4 border-b border-border bg-background px-5 py-4">
             <div>
               <h2
                 id="carbonsage-agent-title"
                 className="font-semibold text-primary"
               >
-                CarbonSage decision agent
+                CarbonSage
               </h2>
               <p className="mt-1 text-xs text-muted-foreground">
-                Workspace-scoped · typed tools · policy v1.0
+                Decisions grounded in this workspace
               </p>
             </div>
             <div className="flex items-center gap-3">
@@ -273,10 +417,10 @@ export default function ChatInterface({
                   aria-hidden="true"
                   className={`h-2 w-2 rounded-full ${
                     assistantStatus === "available"
-                      ? "bg-emerald-500"
+                      ? "bg-accent"
                       : assistantStatus === "checking"
                         ? "animate-pulse bg-amber-500"
-                        : "bg-slate-400"
+                        : "bg-zinc-400"
                   }`}
                 />
                 {statusLabels[assistantStatus]}
@@ -285,8 +429,8 @@ export default function ChatInterface({
                 <button
                   type="button"
                   onClick={() => handleToggleChat(false)}
-                  aria-label="Close CarbonSage agent"
-                  className="rounded-full p-1 text-primary transition hover:bg-border"
+                  aria-label="Close CarbonSage"
+                  className="rounded-full p-1 text-muted-foreground transition hover:bg-muted hover:text-primary"
                 >
                   <X aria-hidden="true" className="h-5 w-5" />
                 </button>
@@ -294,69 +438,191 @@ export default function ChatInterface({
             </div>
           </header>
 
-          <div
-            className="flex-1 space-y-4 overflow-y-auto bg-muted/40 px-3 py-4 sm:px-5"
-            aria-live="polite"
-          >
-            {messages.map((message) => (
-              <article
-                key={message.id}
-                className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
-              >
-                <div
-                  className={`min-w-0 max-w-[94%] rounded-2xl px-4 py-3 sm:max-w-[88%] ${
-                    message.role === "user"
-                      ? "bg-secondary text-white"
-                      : message.isError
-                        ? "border border-red-300 bg-red-50 text-red-900"
-                        : "border border-border bg-muted text-primary"
-                  }`}
+          {isPanel ? (
+            <div className="border-b border-border bg-background px-4 py-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <label htmlFor="agent-conversation" className="sr-only">
+                  Conversation
+                </label>
+                <select
+                  id="agent-conversation"
+                  value={activeConversation?.conversation_id ?? ""}
+                  onChange={(event) =>
+                    void handleSelectConversation(event.target.value)
+                  }
+                  disabled={isSwitchingConversation || !conversations.length}
+                  className="min-w-0 flex-1 rounded-lg border border-border bg-card px-3 py-2 text-sm text-primary disabled:text-muted-foreground sm:min-w-56"
                 >
-                  <p className="mb-2 text-xs font-semibold">
-                    {message.role === "user" ? "You" : "CarbonSage"}
-                  </p>
-                  {message.response ? (
-                    <StructuredResponse
-                      response={message.response}
-                      onAction={onAction}
-                    />
-                  ) : (
-                    <p className="whitespace-pre-wrap text-sm leading-6">
-                      {message.content}
-                    </p>
-                  )}
-                  <p className="mt-3 text-[11px] opacity-65">
-                    {message.timestamp.toLocaleTimeString([], {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                    {message.response
-                      ? ` · ${message.response.processing_time_ms} ms · evidence ${message.response.evidence_status.replaceAll("_", " ")}`
-                      : ""}
-                  </p>
-                </div>
-              </article>
-            ))}
-            {isLoading ? <LoadingIndicator /> : null}
-            <div ref={messagesEndRef} />
-          </div>
+                  {!conversations.length ? (
+                    <option value="">No saved conversations</option>
+                  ) : null}
+                  {conversations.map((conversation) => (
+                    <option
+                      key={conversation.conversation_id}
+                      value={conversation.conversation_id}
+                    >
+                      {conversation.title}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => void handleNewConversation()}
+                  disabled={
+                    isSwitchingConversation ||
+                    conversations.length >= 3 ||
+                    assistantStatus !== "available"
+                  }
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-primary transition hover:border-accent disabled:cursor-not-allowed disabled:opacity-45"
+                >
+                  <Plus aria-hidden="true" className="h-4 w-4" />
+                  New
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleCloseConversation()}
+                  disabled={isSwitchingConversation || !activeConversation}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-muted-foreground transition hover:border-red-300 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-45"
+                >
+                  <Trash2 aria-hidden="true" className="h-4 w-4" />
+                  Close
+                </button>
+              </div>
+              {controlError ? (
+                <p role="alert" className="mt-2 text-xs text-red-700">
+                  {controlError}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
 
-          <ChatInput
-            sendMessage={handleSendMessage}
-            disabled={inputDisabled}
-            placeholder={inputPlaceholder}
-          />
+          {isPanel ? (
+            <details className="border-b border-border bg-muted/55 lg:hidden">
+              <summary className="cursor-pointer px-4 py-3 text-sm font-medium text-primary">
+                Response details
+                {latestResponse
+                  ? ` · ${latestResponse.processing_time_ms} ms`
+                  : ""}
+              </summary>
+              <AgentDetailsPanel
+                availability={assistantStatus}
+                conversation={activeConversation}
+                response={latestResponse}
+                toolEvents={toolEvents}
+                className="max-h-64 border-l-0 p-4"
+                showTitle={false}
+              />
+            </details>
+          ) : null}
+
+          <div
+            className={`min-h-0 flex-1 ${
+              isPanel
+                ? "flex flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_19rem]"
+                : "flex flex-col"
+            }`}
+          >
+            <div className="flex min-h-0 flex-col">
+              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto bg-background px-4 py-5 sm:px-5">
+                {!messages.length && !isLoading ? (
+                  <div className="mx-auto flex h-full max-w-xl flex-col items-center justify-center py-8 text-center">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-card text-accent">
+                      <Leaf aria-hidden="true" className="h-5 w-5" />
+                    </div>
+                    <h3 className="mt-4 text-lg font-semibold text-primary">
+                      What would you like to review?
+                    </h3>
+                    <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+                      Ask about workspace files, supplier evidence, emissions,
+                      scenarios, or report data.
+                    </p>
+                    {assistantStatus === "available" && conversationReady ? (
+                      <div className="mt-5 flex flex-wrap justify-center gap-2">
+                        {suggestedPrompts.map((prompt) => (
+                          <button
+                            key={prompt}
+                            type="button"
+                            onClick={() => void handleSendMessage(prompt)}
+                            className="rounded-full border border-border bg-card px-3 py-2 text-xs font-medium text-primary transition hover:border-accent"
+                          >
+                            {prompt}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+
+                {messages.map((message) => (
+                  <article
+                    key={message.id}
+                    className={`flex ${
+                      message.role === "user" ? "justify-end" : "justify-start"
+                    }`}
+                  >
+                    <div
+                      className={`min-w-0 max-w-[94%] rounded-2xl px-4 py-3 sm:max-w-[88%] ${
+                        message.role === "user"
+                          ? "bg-primary text-background"
+                          : message.isError
+                            ? "border border-red-300 bg-red-50 text-red-900"
+                            : "border border-border bg-card text-primary"
+                      }`}
+                    >
+                      <p className="mb-2 text-xs font-semibold">
+                        {message.role === "user" ? "You" : "CarbonSage"}
+                      </p>
+                      {message.response ? (
+                        <StructuredResponse
+                          response={message.response}
+                          onAction={onAction}
+                        />
+                      ) : (
+                        <p className="whitespace-pre-wrap text-sm leading-6">
+                          {message.content}
+                        </p>
+                      )}
+                      <p className="mt-3 text-[11px] opacity-60">
+                        {message.timestamp.toLocaleTimeString([], {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </p>
+                    </div>
+                  </article>
+                ))}
+                {isLoading ? <LoadingIndicator /> : null}
+                <div ref={messagesEndRef} />
+              </div>
+
+              <ChatInput
+                sendMessage={handleSendMessage}
+                disabled={inputDisabled}
+                placeholder={inputPlaceholder}
+              />
+            </div>
+
+            {isPanel ? (
+              <AgentDetailsPanel
+                availability={assistantStatus}
+                conversation={activeConversation}
+                response={latestResponse}
+                toolEvents={toolEvents}
+                className="hidden lg:block"
+              />
+            ) : null}
+          </div>
         </section>
       ) : isPanel ? null : (
         <button
           type="button"
           onClick={() => handleToggleChat(true)}
-          aria-label="Open CarbonSage decision agent"
-          className="group fixed bottom-4 right-4 z-50 rounded-full border border-green-700 bg-accent p-4 text-white shadow-lg transition hover:bg-secondary"
+          aria-label="Open CarbonSage"
+          className="group fixed bottom-4 right-4 z-50 rounded-full border border-border bg-primary p-4 text-background shadow-lg transition hover:-translate-y-0.5 hover:border-accent"
         >
           <Leaf
             aria-hidden="true"
-            className="h-6 w-6 transition-transform group-hover:scale-110"
+            className="h-6 w-6 transition-transform group-hover:scale-105"
           />
         </button>
       )}

--- a/nzeroesg-client/app/components/chat_ui/LoadingIndicator.tsx
+++ b/nzeroesg-client/app/components/chat_ui/LoadingIndicator.tsx
@@ -1,32 +1,21 @@
-import { Leaf, Sparkles } from "lucide-react";
+import { Leaf } from "lucide-react";
 
 export function LoadingIndicator() {
   return (
-    <div className="flex gap-4 justify-start group">
-      <div className="flex-shrink-0 w-10 h-10 bg-gradient-to-br from-green-500 to-emerald-600 rounded-2xl flex items-center justify-center shadow-lg shadow-green-500/25 relative">
-        <Leaf className="h-5 w-5 text-white" />
-        <div className="absolute -top-1 -right-1 w-4 h-4 bg-gradient-to-r from-yellow-400 to-orange-400 rounded-full flex items-center justify-center animate-pulse">
-          <Sparkles className="h-2 w-2 text-white" />
-        </div>
+    <div className="flex items-start gap-3">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-border bg-card text-accent">
+        <Leaf aria-hidden="true" className="h-4 w-4" />
       </div>
-
-      <div className="bg-white/10 backdrop-blur-sm rounded-3xl px-6 py-2 border border-white/20 shadow-lg">
-        <div className="flex items-center gap-3">
-          <div className="flex gap-1">
-            <div
-              className="w-2 h-2 bg-green-400 rounded-full animate-bounce"
-              style={{ animationDelay: "0ms" }}
+      <div className="rounded-2xl border border-border bg-card px-4 py-3">
+        <p className="mb-2 text-xs font-semibold text-primary">CarbonSage</p>
+        <div className="flex gap-1.5" aria-label="CarbonSage is responding">
+          {[0, 1, 2].map((index) => (
+            <span
+              key={index}
+              className="h-1.5 w-1.5 animate-bounce rounded-full bg-accent"
+              style={{ animationDelay: `${index * 150}ms` }}
             />
-            <div
-              className="w-2 h-2 bg-green-400 rounded-full animate-bounce"
-              style={{ animationDelay: "150ms" }}
-            />
-            <div
-              className="w-2 h-2 bg-green-400 rounded-full animate-bounce"
-              style={{ animationDelay: "300ms" }}
-            />
-          </div>
-          <span className="text-sm text-white/80">Analyzing with AI...</span>
+          ))}
         </div>
       </div>
     </div>

--- a/nzeroesg-client/app/components/chat_ui/StructuredResponse.tsx
+++ b/nzeroesg-client/app/components/chat_ui/StructuredResponse.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { AlertTriangle, BarChart3, FileText, Quote } from "lucide-react";
 
 import type {
@@ -232,7 +233,7 @@ function Block({
   if (!isRecord(value) || typeof value.type !== "string") {
     return (
       <p role="status" className="rounded-lg border border-border p-3 text-xs">
-        CarbonSage received an unreadable response block.
+        Some response details could not be displayed.
       </p>
     );
   }
@@ -276,8 +277,8 @@ function Block({
     case "artifact_reference": {
       const block = value as ArtifactReferenceBlock;
       return (
-        <a
-          href="#artifacts"
+        <Link
+          href={`/dashboard/artifacts?artifact=${encodeURIComponent(block.artifact_id)}`}
           className="flex items-start gap-3 rounded-xl border border-border bg-background p-4 transition hover:border-accent"
         >
           <FileText
@@ -293,7 +294,7 @@ function Block({
               {block.artifact_id.slice(0, 8)}
             </span>
           </span>
-        </a>
+        </Link>
       );
     }
     case "warning": {
@@ -319,8 +320,7 @@ function Block({
           role="status"
           className="rounded-lg border border-border p-3 text-xs"
         >
-          This response includes a newer “{value.type}” block. Update the host
-          renderer to display it.
+          This response includes an item that cannot be displayed here yet.
         </p>
       );
   }

--- a/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
+++ b/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
@@ -47,6 +47,7 @@ const sourceLabels: Record<Artifact["source_type"], string> = {
 type ArtifactCatalogProps = {
   refreshToken: number;
   onDeleted: (kind: ArtifactKind) => void | Promise<void>;
+  focusedArtifactId?: string;
 };
 
 type SourceRetention = {
@@ -76,8 +77,10 @@ function sourceRetentionFor(artifact: Artifact): SourceRetention | null {
 export default function ArtifactCatalog({
   refreshToken,
   onDeleted,
+  focusedArtifactId,
 }: ArtifactCatalogProps) {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -106,11 +109,21 @@ export default function ArtifactCatalog({
               : "Workspace artifacts could not be loaded.",
           );
         }
+      })
+      .finally(() => {
+        if (isCurrent) setIsLoading(false);
       });
     return () => {
       isCurrent = false;
     };
   }, [refreshToken]);
+
+  useEffect(() => {
+    if (!focusedArtifactId || !artifacts.length) return;
+    document
+      .getElementById(`artifact-${focusedArtifactId}`)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [artifacts, focusedArtifactId]);
 
   async function renameArtifact(artifact: Artifact) {
     const title = draftTitle.trim();
@@ -223,19 +236,21 @@ export default function ArtifactCatalog({
   return (
     <section
       id="artifacts"
-      className="mt-8 rounded-xl border border-border bg-muted p-6"
+      className="rounded-xl border border-border bg-card p-5 sm:p-6"
     >
-      <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-accent">
-        Artifact registry
-      </p>
-      <h2 className="text-2xl font-semibold text-primary">
-        Workspace artifacts
-      </h2>
-      <p className="mt-2 max-w-3xl leading-7 text-muted-foreground">
-        Track the source, status, and provenance of uploaded datasets, supplier
-        evidence, and saved decision reports. Supported upload sources are kept
-        private for at most 24 hours, then removed automatically.
-      </p>
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-primary">
+            Files & reports
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Uploaded sources and saved outputs in this workspace.
+          </p>
+        </div>
+        <span className="text-sm text-muted-foreground">
+          {isLoading ? "Loading…" : `${artifacts.length} active`}
+        </span>
+      </div>
 
       {error ? (
         <p className="mt-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
@@ -246,7 +261,9 @@ export default function ArtifactCatalog({
         {statusMessage}
       </p>
 
-      {artifacts.length === 0 ? (
+      {isLoading ? (
+        <p className="mt-5 text-sm text-muted-foreground">Loading files…</p>
+      ) : artifacts.length === 0 ? (
         <p className="mt-5 rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
           No active artifacts yet. Upload shipment data or supplier evidence to
           create the first workspace artifact.
@@ -258,7 +275,12 @@ export default function ArtifactCatalog({
             return (
               <article
                 key={artifact.artifact_id}
-                className="min-w-0 rounded-lg border border-border bg-background p-4"
+                id={`artifact-${artifact.artifact_id}`}
+                className={`min-w-0 rounded-lg border bg-background p-4 transition ${
+                  focusedArtifactId === artifact.artifact_id
+                    ? "border-accent ring-2 ring-accent/20"
+                    : "border-border"
+                }`}
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0">
@@ -294,25 +316,13 @@ export default function ArtifactCatalog({
 
                 <details className="mt-4 text-sm text-muted-foreground">
                   <summary className="cursor-pointer font-semibold text-primary">
-                    Inspect provenance
+                    Source details
                   </summary>
                   <dl className="mt-3 space-y-2">
-                    <div>
-                      <dt className="text-xs">Artifact ID</dt>
-                      <dd className="break-all font-mono text-xs">
-                        {artifact.artifact_id}
-                      </dd>
-                    </div>
                     <div>
                       <dt className="text-xs">Source reference</dt>
                       <dd className="break-words">
                         {artifact.source_reference ?? "Generated in workspace"}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs">Content identity</dt>
-                      <dd className="break-all font-mono text-xs">
-                        {artifact.content_sha256 ?? "No source hash"}
                       </dd>
                     </div>
                     <div>

--- a/nzeroesg-client/app/dashboard/WorkspaceSectionPage.tsx
+++ b/nzeroesg-client/app/dashboard/WorkspaceSectionPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type ChangeEvent, type FormEvent, useEffect, useState } from "react";
+import Link from "next/link";
 
 import { getBackendUrl } from "@/app/api/urls";
 import ArtifactCatalog, {
@@ -127,37 +128,31 @@ export type WorkspaceSection =
 
 const sectionDetails: Record<
   WorkspaceSection,
-  { eyebrow: string; title: string; description: string }
+  { title: string; description: string }
 > = {
   overview: {
-    eyebrow: "Private workspace",
     title: "Overview",
     description:
-      "Review traceable shipment calculations, supplier evidence, and decision-ready reports in one isolated workspace.",
+      "A quick view of your workspace activity and the next useful actions.",
   },
   artifacts: {
-    eyebrow: "Source management",
     title: "Artifacts",
     description:
-      "Manage the datasets, evidence documents, and generated reports owned by this workspace.",
+      "Manage uploaded datasets, evidence documents, and saved reports.",
   },
   shipments: {
-    eyebrow: "Freight analysis",
     title: "Shipments",
     description:
-      "Ingest shipment records and inspect normalized emissions calculations with visible provenance.",
+      "Upload freight data and review emissions, routes, and data quality.",
   },
   evidence: {
-    eyebrow: "Supplier intelligence",
     title: "Suppliers & evidence",
     description:
-      "Manage supplier records, source documents, retrieval modes, and recoverable citations.",
+      "Add supplier documents and find source-backed answers across them.",
   },
   scenarios: {
-    eyebrow: "Decision analysis",
     title: "Scenarios",
-    description:
-      "Compare validated freight alternatives while keeping factors and assumptions visible.",
+    description: "Compare freight alternatives using the same shipment inputs.",
   },
 };
 
@@ -170,8 +165,10 @@ function formatExpiry(timestamp: number) {
 
 export function WorkspaceSectionPage({
   section,
+  focusedArtifactId,
 }: {
   section: WorkspaceSection;
+  focusedArtifactId?: string;
 }) {
   const { session, refreshSession } = useWorkspace();
   const details = sectionDetails[section];
@@ -456,68 +453,95 @@ export function WorkspaceSectionPage({
   );
 
   return (
-    <section className="min-w-0 px-4 py-8 sm:px-6 lg:px-10 lg:py-12">
-      <header className="mb-10">
-        <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-accent">
-          {details.eyebrow}
-        </p>
-        <h1 className="text-4xl font-bold tracking-tight text-primary">
+    <section className="min-w-0 px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
+      <header className="mb-7">
+        <h1 className="text-3xl font-bold tracking-tight text-primary sm:text-4xl">
           {details.title}
         </h1>
-        <p className="mt-3 max-w-3xl leading-7 text-muted-foreground">
+        <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
           {details.description}
         </p>
       </header>
 
       {section === "overview" ? (
         <>
-          <div className="grid gap-5 md:grid-cols-3">
-            <article className="rounded-xl border border-border bg-muted p-5">
-              <p className="text-sm text-muted-foreground">
-                Workspace retention
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <article className="rounded-xl border border-border bg-card p-5">
+              <p className="text-sm text-muted-foreground">Workspace</p>
+              <p className="mt-2 flex items-center gap-2 text-2xl font-bold text-primary">
+                <span className="h-2.5 w-2.5 rounded-full bg-accent" />
+                Active
               </p>
-              <p className="mt-2 text-2xl font-bold text-primary">Active</p>
-              <p className="mt-2 text-sm text-muted-foreground">
+              <p className="mt-2 text-xs text-muted-foreground">
                 Expires {formatExpiry(session.retention.expires_at)}
               </p>
             </article>
-            <article className="rounded-xl border border-border bg-muted p-5">
-              <p className="text-sm text-muted-foreground">
-                Evidence documents
-              </p>
+            <article className="rounded-xl border border-border bg-card p-5">
+              <p className="text-sm text-muted-foreground">Evidence files</p>
               <p className="mt-2 text-2xl font-bold text-primary">
                 {session.quotas.evidence_documents.used} /{" "}
                 {session.quotas.evidence_documents.limit}
               </p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Documents per workspace
-              </p>
+              <p className="mt-2 text-xs text-muted-foreground">Uploaded</p>
             </article>
-            <article className="rounded-xl border border-border bg-muted p-5">
-              <p className="text-sm text-muted-foreground">
-                Analysis runs today
-              </p>
+            <article className="rounded-xl border border-border bg-card p-5">
+              <p className="text-sm text-muted-foreground">Analysis runs</p>
               <p className="mt-2 text-2xl font-bold text-primary">
                 {session.quotas.analysis_runs_per_day.used} /{" "}
                 {session.quotas.analysis_runs_per_day.limit}
               </p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Deterministic calculations
+              <p className="mt-2 text-xs text-muted-foreground">Today</p>
+            </article>
+            <article className="rounded-xl border border-border bg-card p-5">
+              <p className="text-sm text-muted-foreground">Agent requests</p>
+              <p className="mt-2 text-2xl font-bold text-primary">
+                {session.quotas.assistant_requests_per_day.used} /{" "}
+                {session.quotas.assistant_requests_per_day.limit}
               </p>
+              <p className="mt-2 text-xs text-muted-foreground">Today</p>
             </article>
           </div>
 
-          <div className="mt-8 rounded-xl border border-border bg-muted p-6">
-            <h2 className="text-xl font-semibold text-primary">
-              Private by default
+          <section className="mt-8" aria-labelledby="workspace-actions-title">
+            <h2
+              id="workspace-actions-title"
+              className="text-lg font-semibold text-primary"
+            >
+              Continue your work
             </h2>
-            <p className="mt-3 leading-7 text-muted-foreground">
-              Workspace data is available only after the API accepts the signed,
-              expiring session cookie. Every artifact, retrieval, calculation,
-              report, and agent request is scoped to that authenticated
-              workspace.
-            </p>
-          </div>
+            <div className="mt-4 grid gap-4 md:grid-cols-3">
+              {[
+                {
+                  href: "/dashboard/shipments",
+                  title: "Add shipment data",
+                  description: "Upload a CSV and review freight emissions.",
+                },
+                {
+                  href: "/dashboard/evidence",
+                  title: "Add supplier evidence",
+                  description: "Upload documents and search their contents.",
+                },
+                {
+                  href: "/dashboard/agent",
+                  title: "Ask CarbonSage",
+                  description: "Explore the workspace in a conversation.",
+                },
+              ].map((action) => (
+                <Link
+                  key={action.href}
+                  href={action.href}
+                  className="rounded-xl border border-border bg-card p-5 transition hover:-translate-y-0.5 hover:border-accent hover:shadow-sm"
+                >
+                  <span className="font-semibold text-primary">
+                    {action.title}
+                  </span>
+                  <span className="mt-2 block text-sm leading-6 text-muted-foreground">
+                    {action.description}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </section>
         </>
       ) : null}
 
@@ -525,6 +549,7 @@ export function WorkspaceSectionPage({
         <ArtifactCatalog
           refreshToken={artifactRefreshToken}
           onDeleted={handleArtifactDeleted}
+          focusedArtifactId={focusedArtifactId}
         />
       ) : null}
 
@@ -537,19 +562,16 @@ export function WorkspaceSectionPage({
       {section === "shipments" ? (
         <section
           id="shipments"
-          className="rounded-xl border border-border bg-muted p-6"
+          className="rounded-xl border border-border bg-card p-5 sm:p-6"
         >
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-accent">
-                Validated ingestion
-              </p>
               <h2 className="text-2xl font-semibold text-primary">
-                Shipment baseline
+                Upload shipments
               </h2>
               <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
-                Upload the documented CSV schema. Invalid rows stay visible as
-                quality warnings while accepted rows are normalized and counted.
+                Add a CSV to calculate the current freight baseline. Any rows
+                that need attention will stay visible below.
               </p>
             </div>
             <span className="rounded-full border border-border bg-background px-3 py-1 text-xs font-semibold text-primary">
@@ -799,19 +821,15 @@ export function WorkspaceSectionPage({
       {section === "evidence" ? (
         <section
           id="evidence"
-          className="rounded-xl border border-border bg-muted p-6"
+          className="rounded-xl border border-border bg-card p-5 sm:p-6"
         >
           <div>
-            <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-accent">
-              Grounded retrieval
-            </p>
             <h2 className="text-2xl font-semibold text-primary">
-              Supplier evidence
+              Add supplier evidence
             </h2>
             <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
-              Upload a text-based supplier document, record the structured facts
-              you know, and search the extracted text with recoverable
-              citations.
+              Upload a text or PDF document, add the supplier details you know,
+              and search the original source.
             </p>
           </div>
 
@@ -934,8 +952,8 @@ export function WorkspaceSectionPage({
                         Missing metadata: {supplier.missing_fields.join(", ")}
                       </p>
                     ) : (
-                      <p className="mt-4 text-xs text-emerald-800">
-                        Structured metadata is complete.
+                      <p className="mt-4 text-xs text-muted-foreground">
+                        Supplier details complete.
                       </p>
                     )}
                   </article>
@@ -964,7 +982,7 @@ export function WorkspaceSectionPage({
                   }
                   className="rounded-lg border border-border bg-background px-3 py-2 font-normal capitalize"
                 >
-                  <option value="lexical">Lexical</option>
+                  <option value="lexical">Keyword</option>
                   <option value="semantic">Semantic</option>
                   <option value="hybrid">Hybrid</option>
                 </select>
@@ -981,10 +999,9 @@ export function WorkspaceSectionPage({
 
           {evidenceSearchData ? (
             <p className="mt-3 text-xs text-muted-foreground">
-              Used {evidenceSearchData.mode} retrieval · semantic provider{" "}
-              {evidenceSearchData.semantic_available
-                ? "available"
-                : "unavailable"}
+              {evidenceSearchData.mode === "lexical"
+                ? "Keyword search"
+                : `${evidenceSearchData.mode[0].toUpperCase()}${evidenceSearchData.mode.slice(1)} search`}
               {evidenceSearchData.warning
                 ? ` · ${evidenceSearchData.warning}`
                 : ""}
@@ -1030,20 +1047,16 @@ export function WorkspaceSectionPage({
       {section === "scenarios" ? (
         <section
           id="scenarios"
-          className="rounded-xl border border-border bg-muted p-6"
+          className="rounded-xl border border-border bg-card p-5 sm:p-6"
         >
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-accent">
-                Deterministic comparison
-              </p>
               <h2 className="text-2xl font-semibold text-primary">
-                Scenario comparison
+                Compare an alternative
               </h2>
               <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
-                Compare the current shipment modes with one consistent
-                alternative while keeping the factor source and assumptions
-                visible.
+                Apply one freight mode to the current shipment inputs and see
+                the difference from the baseline.
               </p>
             </div>
           </div>
@@ -1111,7 +1124,7 @@ export function WorkspaceSectionPage({
                   <p
                     className={`mt-1 text-2xl font-bold ${
                       scenarioData.delta_kg <= 0
-                        ? "text-emerald-700"
+                        ? "text-accent"
                         : "text-red-700"
                     }`}
                   >
@@ -1217,7 +1230,7 @@ export function WorkspaceSectionPage({
                         <td
                           className={`px-4 py-3 font-semibold ${
                             result.delta_kg <= 0
-                              ? "text-emerald-700"
+                              ? "text-accent"
                               : "text-red-700"
                           }`}
                         >

--- a/nzeroesg-client/app/dashboard/WorkspaceShell.tsx
+++ b/nzeroesg-client/app/dashboard/WorkspaceShell.tsx
@@ -10,6 +10,16 @@ import {
 } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import {
+  Building2,
+  ChartNoAxesCombined,
+  Files,
+  LayoutDashboard,
+  Leaf,
+  MessageSquareText,
+  Route,
+  Truck,
+} from "lucide-react";
 
 import { getBackendUrl } from "@/app/api/urls";
 import ChatInterface from "@/app/components/chat_ui/ChatInterface";
@@ -32,13 +42,17 @@ type WorkspaceContextValue = {
 const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
 
 const navigation = [
-  { label: "Overview", href: "/dashboard" },
-  { label: "Artifacts", href: "/dashboard/artifacts" },
-  { label: "Shipments", href: "/dashboard/shipments" },
-  { label: "Suppliers & evidence", href: "/dashboard/evidence" },
-  { label: "Scenarios", href: "/dashboard/scenarios" },
-  { label: "Report", href: "/dashboard/report" },
-  { label: "Agent", href: "/dashboard/agent" },
+  { label: "Overview", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Artifacts", href: "/dashboard/artifacts", icon: Files },
+  { label: "Shipments", href: "/dashboard/shipments", icon: Truck },
+  {
+    label: "Suppliers & evidence",
+    href: "/dashboard/evidence",
+    icon: Building2,
+  },
+  { label: "Scenarios", href: "/dashboard/scenarios", icon: Route },
+  { label: "Report", href: "/dashboard/report", icon: ChartNoAxesCombined },
+  { label: "Agent", href: "/dashboard/agent", icon: MessageSquareText },
 ];
 
 export function useWorkspace() {
@@ -131,19 +145,22 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
 
   return (
     <WorkspaceContext.Provider value={{ session, refreshSession }}>
-      <div className="mx-auto flex min-h-screen w-full max-w-[96rem] flex-col overflow-x-clip lg:flex-row">
-        <aside className="sticky top-0 z-40 border-b border-border bg-background px-4 py-4 lg:h-screen lg:w-72 lg:shrink-0 lg:overflow-y-auto lg:border-b-0 lg:border-r lg:px-6 lg:py-8">
+      <div className="mx-auto flex min-h-screen w-full max-w-[100rem] flex-col overflow-x-clip lg:flex-row">
+        <aside className="sticky top-0 z-40 border-b border-border bg-card/95 px-4 py-4 backdrop-blur lg:h-screen lg:w-72 lg:shrink-0 lg:overflow-y-auto lg:border-b-0 lg:border-r lg:px-6 lg:py-7">
           <div className="flex items-center justify-between gap-4 lg:block">
-            <div>
-              <Link
-                href="/"
-                className="text-xl font-bold tracking-tight text-primary"
-              >
-                🌱 CarbonSage
-              </Link>
-              <p className="mt-1 text-xs text-muted-foreground lg:mt-2 lg:text-sm">
-                ESG agent control plane
-              </p>
+            <div className="flex items-center gap-3">
+              <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-border bg-muted text-accent">
+                <Leaf aria-hidden="true" className="h-4 w-4" />
+              </span>
+              <div>
+                <Link
+                  href="/"
+                  className="text-lg font-bold tracking-tight text-primary"
+                >
+                  CarbonSage
+                </Link>
+                <p className="text-xs text-muted-foreground">Workspace</p>
+              </div>
             </div>
             <button
               type="button"
@@ -156,9 +173,10 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
 
           <nav
             aria-label="Workspace navigation"
-            className="mt-4 flex gap-2 overflow-x-auto pb-1 lg:mt-10 lg:block lg:space-y-2 lg:overflow-visible lg:pb-0"
+            className="mt-4 flex gap-2 overflow-x-auto pb-1 lg:mt-8 lg:block lg:space-y-1 lg:overflow-visible lg:pb-0"
           >
             {navigation.map((item) => {
+              const Icon = item.icon;
               const active =
                 item.href === "/dashboard"
                   ? pathname === item.href
@@ -168,12 +186,13 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
                   href={item.href}
                   key={item.href}
                   aria-current={active ? "page" : undefined}
-                  className={`shrink-0 rounded-lg px-3 py-2.5 text-sm transition lg:block ${
+                  className={`inline-flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm transition lg:flex ${
                     active
-                      ? "bg-secondary font-semibold text-white"
-                      : "text-primary hover:bg-muted"
+                      ? "bg-primary font-semibold text-background"
+                      : "text-muted-foreground hover:bg-muted hover:text-primary"
                   }`}
                 >
+                  <Icon aria-hidden="true" className="h-4 w-4" />
                   {item.label}
                 </Link>
               );

--- a/nzeroesg-client/app/dashboard/agent/page.tsx
+++ b/nzeroesg-client/app/dashboard/agent/page.tsx
@@ -5,18 +5,14 @@ import { runWorkspaceAgentAction } from "@/app/dashboard/agent-actions";
 
 export default function AgentPage() {
   return (
-    <section className="px-4 py-8 sm:px-6 lg:px-10 lg:py-12">
-      <header className="mb-8">
-        <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-accent">
-          Workspace intelligence
-        </p>
-        <h1 className="text-4xl font-bold tracking-tight text-primary">
-          Decision agent
+    <section className="px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
+      <header className="mb-6">
+        <h1 className="text-3xl font-bold tracking-tight text-primary sm:text-4xl">
+          Ask CarbonSage
         </h1>
-        <p className="mt-3 max-w-3xl leading-7 text-muted-foreground">
-          Test CarbonSage against the artifacts, evidence, and deterministic
-          calculations in this workspace. Source-backed answers include
-          citations, and numeric responses come from validated tools.
+        <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
+          Explore your workspace, compare freight decisions, and review the
+          sources and calculations behind each answer.
         </p>
       </header>
 

--- a/nzeroesg-client/app/dashboard/artifacts/page.tsx
+++ b/nzeroesg-client/app/dashboard/artifacts/page.tsx
@@ -1,5 +1,15 @@
 import { WorkspaceSectionPage } from "@/app/dashboard/WorkspaceSectionPage";
 
-export default function ArtifactsPage() {
-  return <WorkspaceSectionPage section="artifacts" />;
+export default async function ArtifactsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ artifact?: string | string[] }>;
+}) {
+  const artifact = (await searchParams).artifact;
+  return (
+    <WorkspaceSectionPage
+      section="artifacts"
+      focusedArtifactId={Array.isArray(artifact) ? artifact[0] : artifact}
+    />
+  );
 }

--- a/nzeroesg-client/app/dashboard/layout.tsx
+++ b/nzeroesg-client/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 export const metadata = {
-  title: "CarbonSage Control Plane",
-  description: "Manage workspace evidence and test CarbonSage decisions.",
+  title: "CarbonSage Workspace",
+  description: "Manage freight data, evidence, scenarios, and decisions.",
 };
 
 import { ReactNode } from "react";

--- a/nzeroesg-client/app/dashboard/report/page.tsx
+++ b/nzeroesg-client/app/dashboard/report/page.tsx
@@ -178,21 +178,17 @@ export default function ReportPage() {
     : [];
 
   return (
-    <section className="px-4 py-8 sm:px-6 lg:px-10 lg:py-12">
-      <header className="mb-8">
-        <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-accent">
-          Decision output
-        </p>
-        <h1 className="text-4xl font-bold tracking-tight text-primary">
+    <section className="px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
+      <header className="mb-7">
+        <h1 className="text-3xl font-bold tracking-tight text-primary sm:text-4xl">
           Report
         </h1>
-        <p className="mt-3 max-w-3xl leading-7 text-muted-foreground">
-          Review a current workspace report, compare one freight alternative,
-          save a traceable snapshot, or export the normalized result.
+        <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
+          Review the current results, save a snapshot, or export the data.
         </p>
       </header>
 
-      <div className="flex flex-wrap items-end gap-3 rounded-xl border border-border bg-muted p-5">
+      <div className="flex flex-wrap items-end gap-3 rounded-xl border border-border bg-card p-5">
         <label className="flex min-w-56 flex-1 flex-col gap-2 text-sm font-semibold text-primary">
           Report alternative
           <select
@@ -241,7 +237,7 @@ export default function ReportPage() {
       </div>
 
       {statusMessage ? (
-        <p className="mt-4 rounded-lg border border-emerald-300 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+        <p className="mt-4 rounded-lg border border-accent/35 bg-accent/10 px-4 py-3 text-sm text-primary">
           {statusMessage}
         </p>
       ) : null}
@@ -254,19 +250,19 @@ export default function ReportPage() {
       {report ? (
         <div className="mt-6 space-y-6">
           <div className="grid gap-4 md:grid-cols-3">
-            <article className="rounded-xl border border-border bg-muted p-5">
+            <article className="rounded-xl border border-border bg-card p-5">
               <p className="text-sm text-muted-foreground">Shipments</p>
               <p className="mt-2 text-2xl font-bold text-primary">
                 {report.shipment_analysis.shipment_count}
               </p>
             </article>
-            <article className="rounded-xl border border-border bg-muted p-5">
+            <article className="rounded-xl border border-border bg-card p-5">
               <p className="text-sm text-muted-foreground">Total emissions</p>
               <p className="mt-2 text-2xl font-bold text-primary">
                 {report.shipment_analysis.total_emissions_kg.toFixed(2)} kg CO2e
               </p>
             </article>
-            <article className="rounded-xl border border-border bg-muted p-5">
+            <article className="rounded-xl border border-border bg-card p-5">
               <p className="text-sm text-muted-foreground">Suppliers</p>
               <p className="mt-2 text-2xl font-bold text-primary">
                 {report.suppliers.length}
@@ -275,7 +271,7 @@ export default function ReportPage() {
           </div>
 
           {report.scenario ? (
-            <article className="rounded-xl border border-border bg-muted p-5">
+            <article className="rounded-xl border border-border bg-card p-5">
               <h2 className="text-xl font-semibold text-primary">
                 Scenario comparison
               </h2>
@@ -307,7 +303,7 @@ export default function ReportPage() {
             </article>
           ) : null}
 
-          <article className="overflow-x-auto rounded-xl border border-border bg-muted p-5">
+          <article className="overflow-x-auto rounded-xl border border-border bg-card p-5">
             <h2 className="text-xl font-semibold text-primary">
               Emissions by mode
             </h2>
@@ -348,7 +344,7 @@ export default function ReportPage() {
             )}
           </article>
 
-          <article className="rounded-xl border border-border bg-muted p-5">
+          <article className="rounded-xl border border-border bg-card p-5">
             <h2 className="text-xl font-semibold text-primary">Methodology</h2>
             <p className="mt-3 text-sm leading-6 text-muted-foreground">
               {report.methodology.factor_source} · version{" "}

--- a/nzeroesg-client/app/globals.css
+++ b/nzeroesg-client/app/globals.css
@@ -1,41 +1,39 @@
-/* globals.css - Updated for Tailwind v4 with proper dark mode */
 @import "tailwindcss";
 
-/* Configure dark mode to use class-based switching */
 @theme {
-  --default-transition-duration: 900ms;
+  --default-transition-duration: 180ms;
 }
 
 :root {
-  --background: #f5fcf9;
-  --foreground: #1a1c1d;
-  --secondary-bg: #ecfdf5;
-  --secondary-fg: #334155;
-  --card: #c7e6d4;
-  --card-foreground: #1f2937;
-  --muted: #f0f9f7;
-  --muted-foreground: #64748b;
-  --border: #d1e7dd;
-  --primary: #184235;
-  --secondary: #01682c;
-  --tertiary: #b99100;
-  --accent: #19a777;
+  --background: #f7f7f5;
+  --foreground: #191b19;
+  --secondary-bg: #f0f1ee;
+  --secondary-fg: #414641;
+  --card: #ffffff;
+  --card-foreground: #202320;
+  --muted: #f0f1ee;
+  --muted-foreground: #656b66;
+  --border: #d9ddd8;
+  --primary: #1c201d;
+  --secondary: #28352e;
+  --tertiary: #8a711f;
+  --accent: #607c6b;
 }
 
 .dark {
-  --background: #0f251e;
-  --foreground: #04a949;
-  --secondary-bg: #1a2d25;
-  --secondary-fg: #e2e8f0;
-  --card: #20342d;
-  --card-foreground: #f8fafc;
-  --muted: #1f3b34;
-  --muted-foreground: #bfcad8;
-  --border: #2f4f45;
-  --primary: #cdf7e1;
-  --secondary: #04a949;
-  --tertiary: #f6d45b;
-  --accent: #05ad75;
+  --background: #111311;
+  --foreground: #eff1ed;
+  --secondary-bg: #171a18;
+  --secondary-fg: #d5d9d4;
+  --card: #1a1d1b;
+  --card-foreground: #f3f5f1;
+  --muted: #202421;
+  --muted-foreground: #a9b0aa;
+  --border: #343a35;
+  --primary: #f1f3ef;
+  --secondary: #587061;
+  --tertiary: #c7ad58;
+  --accent: #8ca696;
 }
 
 @theme {
@@ -70,6 +68,15 @@ body {
     color var(--default-transition-duration);
 }
 
+::selection {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 @media print {
   html {
     color-scheme: light;
@@ -99,7 +106,6 @@ body {
   }
 }
 
-/* Additional utility classes for better dark mode support */
 @layer utilities {
   .theme-transition {
     transition:

--- a/nzeroesg-client/app/login/page.tsx
+++ b/nzeroesg-client/app/login/page.tsx
@@ -37,17 +37,13 @@ export default function LoginPage() {
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-background px-6 py-16">
-      <section className="w-full max-w-xl rounded-2xl border border-border bg-muted p-8 shadow-xl sm:p-10">
-        <p className="mb-3 text-sm font-semibold uppercase tracking-widest text-accent">
-          Controlled demo access
-        </p>
+      <section className="w-full max-w-xl rounded-2xl border border-border bg-card p-8 shadow-xl sm:p-10">
         <h1 className="mb-4 text-4xl font-bold tracking-tight text-primary">
-          Enter a private workspace
+          Enter the demo workspace
         </h1>
         <p className="mb-8 max-w-lg leading-7 text-muted-foreground">
-          CarbonSage creates a short-lived workspace for this demo. Your session
-          is signed by the API, stored in an HTTP-only cookie, and isolated from
-          other visitors.
+          A private, short-lived workspace is created for your visit. Use it to
+          upload data, review evidence, and try CarbonSage.
         </p>
 
         <div className="mb-8 grid gap-3 text-sm text-primary sm:grid-cols-3">
@@ -56,12 +52,12 @@ export default function LoginPage() {
             <span className="text-muted-foreground">workspace retention</span>
           </div>
           <div className="rounded-lg border border-border bg-background p-4">
-            <strong className="block text-base">3 docs</strong>
-            <span className="text-muted-foreground">evidence allowance</span>
+            <strong className="block text-base">Private</strong>
+            <span className="text-muted-foreground">isolated workspace</span>
           </div>
           <div className="rounded-lg border border-border bg-background p-4">
-            <strong className="block text-base">No LLM</strong>
-            <span className="text-muted-foreground">required for the demo</span>
+            <strong className="block text-base">No account</strong>
+            <span className="text-muted-foreground">start immediately</span>
           </div>
         </div>
 

--- a/nzeroesg-client/app/types/chat.ts
+++ b/nzeroesg-client/app/types/chat.ts
@@ -149,6 +149,12 @@ export type AgentHealth = {
   response_schema_version: string;
 };
 
+export type AgentAvailability =
+  | "checking"
+  | "available"
+  | "disabled"
+  | "unreachable";
+
 export type UiMessage = {
   id: string;
   content: string;

--- a/nzeroesg-client/e2e/demo.spec.ts
+++ b/nzeroesg-client/e2e/demo.spec.ts
@@ -17,13 +17,16 @@ const backendActionTimeout = 30_000;
 async function enterWorkspace(page: Page) {
   await page.goto("/login");
   await expect(
-    page.getByRole("heading", { name: "Enter a private workspace" }),
+    page.getByRole("heading", { name: "Enter the demo workspace" }),
   ).toBeVisible();
   await page.getByRole("button", { name: "Enter demo workspace" }).click();
   await expect(page).toHaveURL(/\/dashboard$/);
-  await expect(page.getByText("Private workspace")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
   await expect(page.getByText(/^Ready$/)).toHaveCount(0);
   await expect(page.getByText(/Phase\s+\d+/)).toHaveCount(0);
+  await expect(
+    page.getByText(/policy v|typed tools|control plane/i),
+  ).toHaveCount(0);
   await expect(page.locator("code")).toHaveCount(0);
 }
 
@@ -95,19 +98,15 @@ test("completes the five-minute demo workflow and exports a report", async ({
 
   await page.getByLabel("Retrieval mode").selectOption("hybrid");
   await page.getByRole("button", { name: "Search citations" }).click();
-  const retrievalStatus = page.getByText(
-    /Used (hybrid|lexical) retrieval · semantic provider (available|unavailable)/,
-  );
+  const retrievalStatus = page.getByText(/(Hybrid|Keyword) search/);
   await expect(retrievalStatus).toBeVisible({ timeout: backendActionTimeout });
   const retrievalStatusText = await retrievalStatus.textContent();
-  if (retrievalStatusText?.includes("provider unavailable")) {
+  if (retrievalStatusText?.includes("Keyword search")) {
     expect(retrievalStatusText).toContain(
       "hybrid search used the lexical baseline",
     );
   } else {
-    expect(retrievalStatusText).toContain(
-      "Used hybrid retrieval · semantic provider available",
-    );
+    expect(retrievalStatusText).toContain("Hybrid search");
   }
 
   await openWorkspacePage(page, "Scenarios", "scenarios");
@@ -115,7 +114,9 @@ test("completes the five-minute demo workflow and exports a report", async ({
   await expect(page.getByText("Current baseline")).toBeVisible({
     timeout: backendActionTimeout,
   });
-  await expect(page.getByText("Scenario comparison")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Compare an alternative" }),
+  ).toBeVisible();
   await expect(page.getByText("Methodology", { exact: true })).toBeVisible();
   await expect(
     page.getByRole("table", { name: "Scenario result by shipment" }),
@@ -218,10 +219,8 @@ test("keeps the deterministic workspace usable when the agent is disabled", asyn
 }) => {
   await enterWorkspace(page);
   await openWorkspacePage(page, "Agent", "agent");
-  await expect(
-    page.getByRole("region", { name: "CarbonSage decision agent" }),
-  ).toBeVisible();
-  await expect(page.getByText("Disabled", { exact: true })).toBeVisible();
+  await expect(page.getByRole("region", { name: "CarbonSage" })).toBeVisible();
+  await expect(page.getByText("Not configured", { exact: true })).toBeVisible();
   await expect(page.getByLabel("Message CarbonSage")).toBeDisabled();
 
   await openWorkspacePage(page, "Shipments", "shipments");
@@ -310,7 +309,7 @@ test("restores the latest workspace conversation before enabling input", async (
   await enterWorkspace(page);
   await openWorkspacePage(page, "Agent", "agent");
   const dialog = page.getByRole("region", {
-    name: "CarbonSage decision agent",
+    name: "CarbonSage",
   });
   await expect(dialog.getByText("What did we validate?")).toBeVisible();
   await expect(
@@ -318,6 +317,80 @@ test("restores the latest workspace conversation before enabling input", async (
   ).toBeVisible();
   await expect(dialog.getByLabel("Message CarbonSage")).toBeEnabled();
   expect(createRequested).toBe(false);
+});
+
+test("creates, switches, and closes workspace conversations", async ({
+  page,
+}) => {
+  const now = new Date().toISOString();
+  const firstConversation = {
+    conversation_id: "00000000-0000-4000-8000-000000000021",
+    workspace_id: "demo-conversations",
+    title: "Decision 1",
+    status: "active",
+    policy_version: "1.0",
+    created_by: "demo-session",
+    created_at: now,
+    updated_at: now,
+    expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+  };
+  const secondConversation = {
+    ...firstConversation,
+    conversation_id: "00000000-0000-4000-8000-000000000022",
+    title: "Decision 2",
+  };
+  let closeRequested = false;
+
+  await page.route("**/agent/health", (route) =>
+    route.fulfill({
+      json: {
+        status: "ok",
+        available: true,
+        policy_version: "1.0",
+        response_schema_version: "1.0",
+      },
+    }),
+  );
+  await page.route("**/agent/conversations", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({
+        json: { conversations: [firstConversation] },
+      });
+    }
+    return route.fulfill({ status: 201, json: secondConversation });
+  });
+  await page.route("**/agent/conversations/*", (route) => {
+    if (route.request().method() === "DELETE") {
+      closeRequested = true;
+      return route.fulfill({ status: 204 });
+    }
+    const conversation = route.request().url().includes("000000000022")
+      ? secondConversation
+      : firstConversation;
+    return route.fulfill({
+      json: { conversation, messages: [], tool_events: [] },
+    });
+  });
+
+  await enterWorkspace(page);
+  await openWorkspacePage(page, "Agent", "agent");
+  const agent = page.getByRole("region", { name: "CarbonSage" });
+  const conversationSelect = agent.getByLabel("Conversation");
+  await expect(conversationSelect).toHaveValue(
+    firstConversation.conversation_id,
+  );
+
+  await agent.getByRole("button", { name: "New" }).click();
+  await expect(conversationSelect).toHaveValue(
+    secondConversation.conversation_id,
+  );
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await agent.getByRole("button", { name: "Close" }).click();
+  await expect(conversationSelect).toHaveValue(
+    firstConversation.conversation_id,
+  );
+  expect(closeRequested).toBe(true);
 });
 
 test("renders a typed interactive response with keyboard-accessible chart data", async ({
@@ -331,6 +404,17 @@ test("renders a typed interactive response with keyboard-accessible chart data",
     "content-type": "application/json",
   });
   const now = new Date().toISOString();
+  const conversation = {
+    conversation_id: "00000000-0000-4000-8000-000000000001",
+    workspace_id: "demo-renderer",
+    title: "Decision 1",
+    status: "active",
+    policy_version: "1.0",
+    created_by: "demo-session",
+    created_at: now,
+    updated_at: now,
+    expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+  };
 
   await page.route("**/agent/health", (route) =>
     route.fulfill({
@@ -353,19 +437,29 @@ test("renders a typed interactive response with keyboard-accessible chart data",
     return route.fulfill({
       status: 201,
       headers: corsHeaders(route),
-      json: {
-        conversation_id: "00000000-0000-4000-8000-000000000001",
-        workspace_id: "demo-renderer",
-        title: "CarbonSage workspace decision",
-        status: "active",
-        policy_version: "1.0",
-        created_by: "demo-session",
-        created_at: now,
-        updated_at: now,
-        expires_at: new Date(Date.now() + 3_600_000).toISOString(),
-      },
+      json: conversation,
     });
   });
+  await page.route("**/agent/conversations/*", (route) =>
+    route.fulfill({
+      headers: corsHeaders(route),
+      json: {
+        conversation,
+        messages: [],
+        tool_events: [
+          {
+            event_id: "00000000-0000-4000-8000-000000000009",
+            tool_name: "calculate_freight_emissions",
+            status: "succeeded",
+            duration_ms: 11,
+            result_count: 2,
+            artifact_ids: [],
+            error_code: null,
+          },
+        ],
+      },
+    }),
+  );
   await page.route("**/agent/conversations/*/messages", (route) =>
     route.fulfill({
       headers: corsHeaders(route),
@@ -501,7 +595,7 @@ test("renders a typed interactive response with keyboard-accessible chart data",
   await expect(page).toHaveURL(/\/dashboard\/agent$/);
 
   const agentDialog = page.getByRole("region", {
-    name: "CarbonSage decision agent",
+    name: "CarbonSage",
   });
   const input = agentDialog.getByLabel("Message CarbonSage");
   await expect(input).toBeEnabled();
@@ -538,8 +632,24 @@ test("renders a typed interactive response with keyboard-accessible chart data",
     agentDialog.getByText("Semantic retrieval fell back to lexical evidence."),
   ).toBeVisible();
   await expect(
-    agentDialog.getByText(/newer “future_decision_block” block/),
+    agentDialog.getByText(
+      "This response includes an item that cannot be displayed here yet.",
+    ),
   ).toBeVisible();
+  await agentDialog.getByText("Response details · 18 ms").click();
+  await expect(agentDialog.getByText("Sources verified").first()).toBeVisible();
+  await expect(
+    agentDialog.getByText("18 ms", { exact: true }).first(),
+  ).toBeVisible();
+  await expect(
+    agentDialog.getByText("Calculated freight emissions").first(),
+  ).toBeVisible();
+  await expect(
+    agentDialog.getByRole("link", { name: "Supplier evidence" }).first(),
+  ).toHaveAttribute(
+    "href",
+    "/dashboard/artifacts?artifact=00000000-0000-4000-8000-000000000006",
+  );
 
   const action = agentDialog.getByRole("button", {
     name: "Save report snapshot",
@@ -568,7 +678,7 @@ test("supports keyboard entry and a narrow viewport", async ({ page }) => {
   await page.keyboard.press("Enter");
 
   await expect(page).toHaveURL(/\/dashboard$/);
-  await expect(page.getByText("Private workspace")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
 
   const viewport = await page.evaluate(() => ({
     width: window.innerWidth,

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,10 @@ management, retrieval, calculations, scenarios, and reports remain available.
   overview, artifact, shipment, supplier-evidence, scenario, report, and agent
   pages. Every section can be linked to or refreshed directly.
 - A dedicated decision-agent testing page using the same workspace-scoped
-  conversation API and structured renderer as the control-plane launcher.
+  conversation API and structured renderer as the workspace launcher. Users
+  can create, switch, and close conversations; inspect source coverage,
+  response time, cited artifacts, and concise tool activity; and follow an
+  artifact reference to the highlighted workspace record.
 - A Vercel client, Render API, Neon PostgreSQL database, and credential-free CI
   and browser checks.
 
@@ -105,12 +108,9 @@ management, retrieval, calculations, scenarios, and reports remain available.
 
 CarbonSage will build on that baseline in a controlled order:
 
-1. Extend the dedicated agent page with evidence-completeness and concise
-   tool-event inspection around its existing conversation history and shared
-   renderer.
-2. Add a framework-independent JavaScript loader and authenticated iframe.
-3. Add one explicit, read-only Google Drive selected-file import.
-4. Optionally expose a read-only MCP adapter over the same stable application
+1. Add a framework-independent JavaScript loader and authenticated iframe.
+2. Add one explicit, read-only Google Drive selected-file import.
+3. Optionally expose a read-only MCP adapter over the same stable application
    tools.
 
 Dropbox, billing, organization administration, background synchronization,


### PR DESCRIPTION
## What changed

- rebuilt the dedicated agent workspace around saved conversation controls, source coverage, response timing, cited artifacts, and human-readable recent work
- linked response artifacts to the matching highlighted workspace record
- replaced synthetic assistant and implementation-oriented interface copy with concise task-focused language
- restyled the workspace and entry flow with neutral surfaces, charcoal actions, and restrained sage accents
- improved overview actions, artifact presentation, mobile response details, navigation hierarchy, and provider-disabled messaging
- updated Phase 10 and current-state documentation

## Why

The existing workspace proved the contracts but still read like a development scaffold. This change makes the implemented vertical slice clear and usable for a reviewer while preserving the RAG, tooling, citation, and deterministic-calculation evidence underneath it.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run test:e2e` — 8 passed
- `python scripts/check_secrets.py`
- `git diff --check`
