### PR TITLE
Keep local workspace cookies on one origin

### DIFF
--- a/nzeroesg-client/app/api/urls.ts
+++ b/nzeroesg-client/app/api/urls.ts
@@ -1,11 +1,27 @@
 export const getBackendUrl = () => {
-  const url = process.env.NEXT_PUBLIC_BACKEND_URL;
-  if (!url) {
+  const configuredUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (!configuredUrl) {
     if (typeof window !== "undefined") {
       return `${window.location.protocol}//${window.location.hostname}:8000`;
     }
     return process.env.NEXT_PUBLIC_BACKEND_URL || "http://backend:8000";
-    // return "http://localhost:8000"; // dev only
   }
-  return url;
+
+  if (typeof window !== "undefined") {
+    try {
+      const backendUrl = new URL(configuredUrl);
+      const localHosts = new Set(["localhost", "127.0.0.1"]);
+      if (
+        localHosts.has(window.location.hostname) &&
+        localHosts.has(backendUrl.hostname)
+      ) {
+        backendUrl.hostname = window.location.hostname;
+        return backendUrl.toString().replace(/\/$/, "");
+      }
+    } catch {
+      return configuredUrl;
+    }
+  }
+
+  return configuredUrl;
 };

--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,10 @@ cp nzeroesg-api/.env.example nzeroesg-api/.env
 cp nzeroesg-client/.env.example nzeroesg-client/.env.local
 ```
 
+Use the same local hostname for the browser and API (`localhost` or
+`127.0.0.1`). The client normalizes those two loopback aliases during local
+development so the HTTP-only workspace cookie is returned consistently.
+
 The historical directory, service, environment-variable, and public URL names
 remain unchanged so the working deployment is not broken by the public rebrand.
 


### PR DESCRIPTION
## What changed

- Normalize `localhost` and `127.0.0.1` to the browser's active loopback hostname when resolving the configured local API URL.
- Document the local-origin requirement for the HTTP-only workspace session cookie.

## Why

Opening the frontend on one loopback alias while the configured API used the other caused the browser to create a workspace successfully but omit its SameSite cookie from the following request, resulting in an immediate `401`.

## Validation

- Prettier, ESLint, TypeScript, and the Next.js production build passed.
- The browser workspace-session and demo-data smoke test passed.
- Secret-pattern and diff checks passed.
