### PR TITLE
Refine dashboard information design

### DIFF
--- a/docs/app.architecture.md
+++ b/docs/app.architecture.md
@@ -76,6 +76,7 @@ each have a standalone URL that can be opened or refreshed directly:
 ├── /integrations
 ├── /overview
 ├── /artifacts
+├── /how-to
 ├── /shipments
 ├── /evidence
 ├── /scenarios

--- a/docs/demo-roadmap.md
+++ b/docs/demo-roadmap.md
@@ -855,10 +855,10 @@ Implementation evidence (completed 2026-08-18):
 - `/dashboard` now opens `/dashboard/agent`, and `Ask CarbonSage` leads the
   persistent navigation. Navigating to another route removes the full agent
   panel; the compact launcher starts closed on each destination.
-- An empty workspace presents an explicit choice between loading a small,
+- An empty workspace presents an explicit choice between loading a guided,
   fictional CarbonSage dataset and uploading user sources. The seed operation
-  is authenticated, idempotent, workspace-scoped, and creates one shipment
-  dataset plus two supplier evidence artifacts.
+  is authenticated, idempotent, workspace-scoped, and creates six shipments,
+  24 supplier profiles, and three cited supplier evidence artifacts.
 - Empty artifact-aware agent responses expose the same
   `workspace.load_demo_data` action through the versioned action-block
   contract. No client-authored mutation name is passed to the model.
@@ -879,7 +879,7 @@ Implementation evidence (completed 2026-08-18):
   remain dominant while the green action and data accents have greater
   contrast.
 - The stale global release banner was removed. Backend unit/integration tests,
-  frontend type checks, lint, production build, and all nine Playwright flows
+  frontend type checks, lint, production build, and all ten Playwright flows
   pass with the new route and form contracts.
 
 Exit gate:
@@ -887,6 +887,44 @@ Exit gate:
 > A new reviewer reaches the agent first, can populate a useful workspace in
 > one click or bring supported files, and can inspect or download every demo
 > data category without reading setup instructions.
+
+### Phase 10.2 — Review-ready workspace information design
+
+Implementation evidence (completed 2026-08-19):
+
+- The desktop shell follows a quieter dashboard hierarchy: a muted-gray
+  sidebar, white content canvas, compact active states, and restrained green
+  accents. `Ask CarbonSage` remains first and `Overview` second.
+- Navigation is grouped into `Workspace` and a collapsible `Simulations`
+  section. The latter contains Shipments, Suppliers, and a deliberately
+  deferred Scenarios page; Report remains a single workspace destination.
+- The profile control is a standalone circular `DW` avatar. Its menu exposes
+  the workspace guide, persisted light/dark mode, and sign-out without the
+  previous account-summary container or chevron.
+- A shared animated spinner covers session resolution, data loading, uploads,
+  searches, agent actions, conversation switches, demo seeding, and report
+  actions. Text-only duplicate loading indicators are removed.
+- Integrations offers the same one-click demo seed as the agent and presents a
+  full-width Google Drive placeholder centered on selected-file authorization,
+  normalization, provenance, and document citation.
+- Artifacts are responsive full-width expandable rows. Each row exposes a
+  three-dot action menu for source download when available, rename, and delete;
+  normalized shipment and supplier downloads are absent until data exists.
+- Shipment imports recognize a supplier export and explain the corrective next
+  step. A zero-row import no longer exposes empty charts, tables, or factor
+  notes as if analysis had succeeded.
+- Scenarios is a concise coming-soon page while scenario comparison remains an
+  agent and report capability. The workspace guide describes the current
+  agent-first path without exposing implementation notes in the primary UI.
+- The expanded fictional seed now provides 24 suppliers, six mixed-mode
+  shipments, and three cited disclosures. API tests, production build, and ten
+  Playwright flows cover the updated data and interaction contracts.
+
+Exit gate:
+
+> A reviewer can understand the workspace hierarchy, load representative data,
+> inspect or manage artifacts, and reach the core agent without encountering
+> placeholder product language, empty exports, or ambiguous loading states.
 
 ### Phase 11 — Authenticated JavaScript embed
 

--- a/nzeroesg-api/api/demo_data.py
+++ b/nzeroesg-api/api/demo_data.py
@@ -23,6 +23,7 @@ from domain.demo_data import (
     DEMO_EVIDENCE_SOURCES,
     DEMO_SHIPMENTS_CSV,
     DEMO_SHIPMENTS_FILENAME,
+    DEMO_SUPPLIERS,
 )
 from domain.evidence.ingestion import extract_evidence, normalize_supplier_metadata
 from domain.evidence.models import SupplierMetadata
@@ -109,6 +110,23 @@ async def load_demo_data(
             "source_retention": generated_source_retention,
         },
     )
+
+    for demo_supplier in DEMO_SUPPLIERS:
+        normalized = normalize_supplier_metadata(
+            name=demo_supplier.name,
+            region=demo_supplier.region,
+            certifications=demo_supplier.certifications,
+            transport_modes=demo_supplier.transport_modes,
+        )
+        evidence_repository.upsert_supplier(
+            principal.workspace_id,
+            SupplierMetadata(
+                name=normalized[0],
+                region=normalized[1],
+                certifications=normalized[2],
+                transport_modes=normalized[3],
+            ),
+        )
 
     for source in DEMO_EVIDENCE_SOURCES:
         normalized = normalize_supplier_metadata(

--- a/nzeroesg-api/domain/demo_data.py
+++ b/nzeroesg-api/domain/demo_data.py
@@ -18,6 +18,42 @@ DEMO_SHIPMENTS_CSV = (
 
 
 @dataclass(frozen=True)
+class DemoSupplier:
+    name: str
+    region: str
+    certifications: str
+    transport_modes: str
+
+
+DEMO_SUPPLIERS = (
+    DemoSupplier("Boreal Components", "Canada", "ISO 14001", "train, truck"),
+    DemoSupplier("Northstar Logistics", "North America", "SmartWay", "truck, train"),
+    DemoSupplier("Aurora Packaging", "Canada", "FSC, ISO 14001", "truck"),
+    DemoSupplier("Prairie Steelworks", "Canada", "ISO 14001", "train, truck"),
+    DemoSupplier("Cascade Textiles", "United States", "OEKO-TEX", "truck, ship"),
+    DemoSupplier("Meridian Electronics", "Taiwan", "ISO 14001", "plane, ship"),
+    DemoSupplier("Evergreen Polymers", "Canada", "ISCC PLUS", "train, truck"),
+    DemoSupplier("Atlas Fasteners", "Mexico", "ISO 9001", "truck"),
+    DemoSupplier("Pacific Circuitry", "Vietnam", "ISO 14001", "ship, plane"),
+    DemoSupplier("Great Lakes Glass", "United States", "ENERGY STAR", "train, truck"),
+    DemoSupplier("Summit Batteries", "South Korea", "RBA", "ship, plane"),
+    DemoSupplier("Horizon Rubber", "Thailand", "ISO 14001", "ship"),
+    DemoSupplier("Cedar Paper Co", "Canada", "FSC", "train, truck"),
+    DemoSupplier("Arctic Insulation", "Canada", "GREENGUARD", "truck"),
+    DemoSupplier("Riverbend Chemicals", "United States", "Responsible Care", "train, truck"),
+    DemoSupplier("Terra Ceramics", "Spain", "ISO 14001", "ship, train"),
+    DemoSupplier("Skyline Freight", "North America", "SmartWay", "truck, train"),
+    DemoSupplier("Redwood Castings", "United States", "ISO 14001", "train, truck"),
+    DemoSupplier("Bluewater Motors", "Germany", "ISO 50001", "ship, train"),
+    DemoSupplier("Solstice Solar Materials", "Malaysia", "ISO 14001", "ship"),
+    DemoSupplier("Nimbus Controls", "Japan", "ISO 14001", "plane, ship"),
+    DemoSupplier("Frontier Composites", "Canada", "ISO 9001", "truck, train"),
+    DemoSupplier("Maple Leaf Warehousing", "Canada", "LEED Gold", "truck, train"),
+    DemoSupplier("Coastal Biofuels", "Canada", "ISCC", "ship, truck"),
+)
+
+
+@dataclass(frozen=True)
 class DemoEvidenceSource:
     key: str
     filename: str
@@ -57,6 +93,21 @@ DEMO_EVIDENCE_SOURCES = (
             b"Its disclosure estimates a 31 percent emissions reduction for eligible intermodal "
             b"routes compared with its conventional truck baseline. Refrigerated service and "
             b"last-mile delivery remain truck-only and should be evaluated separately."
+        ),
+    ),
+    DemoEvidenceSource(
+        key="aurora-packaging-disclosure",
+        filename="aurora-packaging-disclosure.txt",
+        supplier_name="Aurora Packaging",
+        supplier_region="Canada",
+        certifications="FSC, ISO 14001",
+        transport_modes="truck",
+        content=(
+            b"Fictional demo sustainability disclosure for Aurora Packaging. The supplier "
+            b"reports FSC-certified fibre for its corrugated packaging lines and maintains "
+            b"ISO 14001 certification. Its 2025 disclosure states that recovered fibre made "
+            b"up 81 percent of production inputs. Delivery data covers truck routes from the "
+            b"Ontario facility; upstream forestry emissions are reported separately."
         ),
     ),
 )

--- a/nzeroesg-api/domain/shipments/ingestion.py
+++ b/nzeroesg-api/domain/shipments/ingestion.py
@@ -31,6 +31,14 @@ XLSX_CONTENT_TYPES = {
 }
 ALLOWED_CONTENT_TYPES = CSV_CONTENT_TYPES | XLSX_CONTENT_TYPES
 ALLOWED_EXTENSIONS = {".csv", ".xlsx"}
+SUPPLIER_EXPORT_HEADERS = {
+    "supplier_id",
+    "name",
+    "region",
+    "certifications",
+    "transport_modes",
+    "documents",
+}
 
 HEADER_ALIASES = {
     "id": "shipment_id",
@@ -235,11 +243,20 @@ def parse_shipments_csv(
             header for header in REQUIRED_HEADERS if header not in normalized_headers
         ]
         if missing_headers:
+            normalized_header_set = set(normalized_headers)
+            looks_like_supplier_data = (
+                len(normalized_header_set.intersection(SUPPLIER_EXPORT_HEADERS)) >= 3
+            )
             _issue(
                 errors,
                 row_number=1,
                 field=None,
-                message=f"Missing required headers: {', '.join(missing_headers)}.",
+                message=(
+                    "This looks like supplier data. Add supplier records from the Suppliers "
+                    "page, or choose a shipment CSV/XLSX file here."
+                    if looks_like_supplier_data
+                    else f"Missing required headers: {', '.join(missing_headers)}."
+                ),
             )
             return ShipmentParseResult(rows=(), errors=tuple(errors), warnings=())
         ignored_headers = [

--- a/nzeroesg-api/tests/test_api.py
+++ b/nzeroesg-api/tests/test_api.py
@@ -277,14 +277,14 @@ def test_demo_data_is_explicit_idempotent_and_downloadable():
     assert loaded.json() == {
         "loaded": True,
         "has_artifacts": True,
-        "artifact_count": 3,
+        "artifact_count": 4,
         "shipment_count": 6,
-        "supplier_count": 2,
-        "evidence_document_count": 2,
+        "supplier_count": 24,
+        "evidence_document_count": 3,
     }
     assert repeated.status_code == 200
     assert repeated.json()["loaded"] is False
-    assert repeated.json()["artifact_count"] == 3
+    assert repeated.json()["artifact_count"] == 4
 
     artifacts = demo_client.get("/artifacts").json()["artifacts"]
     for artifact in artifacts:
@@ -298,6 +298,7 @@ def test_demo_data_is_explicit_idempotent_and_downloadable():
     assert b"CS-1001" in shipments_export.content
     assert suppliers_export.status_code == 200
     assert b"Boreal Components" in suppliers_export.content
+    assert b"Coastal Biofuels" in suppliers_export.content
 
 
 def test_supplier_can_be_created_before_evidence_is_available():

--- a/nzeroesg-api/tests/test_shipments.py
+++ b/nzeroesg-api/tests/test_shipments.py
@@ -85,6 +85,18 @@ def test_parser_rejects_missing_headers_bad_file_type_and_nul_content():
     assert hostile.errors[0].message == "NUL characters are not allowed in CSV content."
 
 
+def test_supplier_export_gets_a_clear_shipment_import_explanation():
+    result = parse_shipments_csv(
+        b"supplier_id,name,region,certifications,transport_modes,documents\n"
+    )
+
+    assert result.rows == ()
+    assert result.errors[0].message == (
+        "This looks like supplier data. Add supplier records from the Suppliers page, "
+        "or choose a shipment CSV/XLSX file here."
+    )
+
+
 def test_parser_rejects_oversized_and_over_row_limit_files():
     oversized = parse_shipments_csv(b"x" * (MAX_FILE_BYTES + 1))
     rows = HEADER + "".join(

--- a/nzeroesg-client/app/components/Spinner.tsx
+++ b/nzeroesg-client/app/components/Spinner.tsx
@@ -1,0 +1,34 @@
+import { LoaderCircle } from "lucide-react";
+
+export function Spinner({
+  className = "h-4 w-4",
+  label,
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <span
+      role={label ? "status" : undefined}
+      aria-label={label}
+      className="inline-flex shrink-0 items-center justify-center"
+    >
+      <LoaderCircle
+        aria-hidden="true"
+        className={`${className} animate-spin`}
+      />
+    </span>
+  );
+}
+
+export function LoadingState({ label }: { label: string }) {
+  return (
+    <div
+      role="status"
+      className="flex min-h-24 items-center justify-center text-muted-foreground"
+    >
+      <Spinner className="h-5 w-5" />
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}

--- a/nzeroesg-client/app/components/chat_ui/ChatInterface.tsx
+++ b/nzeroesg-client/app/components/chat_ui/ChatInterface.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Database, Leaf, Plus, Trash2, Upload, X } from "lucide-react";
 
 import { getBackendUrl } from "@/app/api/urls";
+import { LoadingState, Spinner } from "@/app/components/Spinner";
 import type {
   AgentAvailability,
   AgentConversation,
@@ -520,6 +521,9 @@ export default function ChatInterface({
                     </option>
                   ))}
                 </select>
+                {isSwitchingConversation ? (
+                  <Spinner label="Updating conversation" />
+                ) : null}
                 <button
                   type="button"
                   onClick={() => void handleNewConversation()}
@@ -579,7 +583,9 @@ export default function ChatInterface({
           >
             <div className="flex min-h-0 flex-col">
               <div className="min-h-0 flex-1 space-y-4 overflow-y-auto bg-background px-4 py-5 sm:px-5">
-                {!messages.length && !isLoading ? (
+                {isSwitchingConversation ? (
+                  <LoadingState label="Loading conversation" />
+                ) : !messages.length && !isLoading ? (
                   <div className="mx-auto flex h-full max-w-xl flex-col items-center justify-center py-8 text-center">
                     <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-card text-accent">
                       <Leaf aria-hidden="true" className="h-5 w-5" />
@@ -591,7 +597,7 @@ export default function ChatInterface({
                     </h3>
                     <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
                       {demoData && !demoData.has_artifacts
-                        ? "This workspace is empty. Load a small fictional supplier and shipment dataset, or upload CSV, XLSX, PDF, or TXT files."
+                        ? "This workspace is empty. Load 24 fictional suppliers, cited disclosures, and a shipment baseline, or upload CSV, XLSX, PDF, or TXT files."
                         : "Ask about workspace files, supplier evidence, emissions, scenarios, or report data."}
                     </p>
                     {demoData && !demoData.has_artifacts ? (
@@ -600,14 +606,18 @@ export default function ChatInterface({
                           type="button"
                           onClick={() => void handleLoadDemoData()}
                           disabled={!onAction || isLoadingDemoData}
-                          className="inline-flex items-center gap-2 rounded-full bg-secondary px-4 py-2 text-xs font-semibold text-white transition hover:bg-accent disabled:opacity-50"
+                          className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-xs font-semibold text-white transition hover:bg-accent disabled:opacity-50"
                         >
-                          <Database aria-hidden="true" className="h-4 w-4" />
-                          {isLoadingDemoData ? "Loading…" : "Load demo data"}
+                          {isLoadingDemoData ? (
+                            <Spinner />
+                          ) : (
+                            <Database aria-hidden="true" className="h-4 w-4" />
+                          )}
+                          Load demo data
                         </button>
                         <Link
                           href="/dashboard/shipments"
-                          className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-xs font-semibold text-primary transition hover:border-accent"
+                          className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3.5 py-2 text-xs font-semibold text-primary transition hover:border-accent"
                         >
                           <Upload aria-hidden="true" className="h-4 w-4" />
                           Upload your own
@@ -620,7 +630,7 @@ export default function ChatInterface({
                             key={prompt}
                             type="button"
                             onClick={() => void handleSendMessage(prompt)}
-                            className="rounded-full border border-border bg-card px-3 py-2 text-xs font-medium text-primary transition hover:border-accent"
+                            className="rounded-lg border border-border bg-card px-3 py-2 text-xs font-medium text-primary transition hover:border-accent"
                           >
                             {prompt}
                           </button>

--- a/nzeroesg-client/app/components/chat_ui/StructuredResponse.tsx
+++ b/nzeroesg-client/app/components/chat_ui/StructuredResponse.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { AlertTriangle, BarChart3, FileText, Quote } from "lucide-react";
 
+import { Spinner } from "@/app/components/Spinner";
 import type {
   ActionBlock,
   AgentResponseEnvelope,
@@ -197,13 +198,10 @@ function Action({
         type="button"
         onClick={run}
         disabled={!onAction || status === "running" || status === "done"}
-        className="rounded-full bg-secondary px-4 py-2 text-xs font-semibold text-white transition hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-xs font-semibold text-white transition hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
       >
-        {status === "running"
-          ? "Running…"
-          : status === "done"
-            ? "Completed"
-            : block.label}
+        {status === "running" ? <Spinner /> : null}
+        {status === "done" ? "Completed" : block.label}
       </button>
       {!onAction ? (
         <p className="mt-2 text-xs text-muted-foreground">

--- a/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
+++ b/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import {
+  ChevronDown,
+  Download,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 
 import { getBackendUrl } from "@/app/api/urls";
+import { LoadingState, Spinner } from "@/app/components/Spinner";
 
 export type ArtifactKind =
   | "shipment_dataset"
@@ -29,6 +37,11 @@ type Artifact = {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+};
+
+type WorkspaceDataStatus = {
+  shipment_count: number;
+  supplier_count: number;
 };
 
 const kindLabels: Record<ArtifactKind, string> = {
@@ -58,9 +71,7 @@ type SourceRetention = {
 
 function sourceRetentionFor(artifact: Artifact): SourceRetention | null {
   const value = artifact.metadata.source_retention;
-  if (!value || typeof value !== "object") {
-    return null;
-  }
+  if (!value || typeof value !== "object") return null;
   const candidate = value as Record<string, unknown>;
   if (candidate.status !== "retained" && candidate.status !== "ephemeral") {
     return null;
@@ -80,41 +91,62 @@ export default function ArtifactCatalog({
   focusedArtifactId,
 }: ArtifactCatalogProps) {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
+  const [dataStatus, setDataStatus] = useState<WorkspaceDataStatus | null>(
+    null,
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(
+    focusedArtifactId ?? null,
+  );
+  const [menuId, setMenuId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftTitle, setDraftTitle] = useState("");
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [busyExport, setBusyExport] = useState<string | null>(null);
 
   useEffect(() => {
     let isCurrent = true;
-    fetch(`${getBackendUrl()}/artifacts`, { credentials: "include" })
-      .then(async (response) => {
-        if (!response.ok) {
+    const controller = new AbortController();
+    Promise.all([
+      fetch(`${getBackendUrl()}/artifacts`, {
+        credentials: "include",
+        signal: controller.signal,
+      }),
+      fetch(`${getBackendUrl()}/demo/data`, {
+        credentials: "include",
+        signal: controller.signal,
+      }),
+    ])
+      .then(async ([artifactResponse, statusResponse]) => {
+        if (!artifactResponse.ok || !statusResponse.ok) {
           throw new Error("Workspace artifacts could not be loaded.");
         }
-        return (await response.json()) as { artifacts: Artifact[] };
+        return Promise.all([
+          artifactResponse.json() as Promise<{ artifacts: Artifact[] }>,
+          statusResponse.json() as Promise<WorkspaceDataStatus>,
+        ]);
       })
-      .then((payload) => {
-        if (isCurrent) {
-          setArtifacts(payload.artifacts);
-        }
+      .then(([artifactPayload, statusPayload]) => {
+        if (!isCurrent) return;
+        setArtifacts(artifactPayload.artifacts);
+        setDataStatus(statusPayload);
       })
       .catch((requestError) => {
-        if (isCurrent) {
-          setError(
-            requestError instanceof Error
-              ? requestError.message
-              : "Workspace artifacts could not be loaded.",
-          );
-        }
+        if (!isCurrent || controller.signal.aborted) return;
+        setError(
+          requestError instanceof Error
+            ? requestError.message
+            : "Workspace artifacts could not be loaded.",
+        );
       })
       .finally(() => {
         if (isCurrent) setIsLoading(false);
       });
     return () => {
       isCurrent = false;
+      controller.abort();
     };
   }, [refreshToken]);
 
@@ -143,9 +175,7 @@ export default function ArtifactCatalog({
           body: JSON.stringify({ title }),
         },
       );
-      if (!response.ok) {
-        throw new Error("Artifact could not be renamed.");
-      }
+      if (!response.ok) throw new Error("Artifact could not be renamed.");
       const updated = (await response.json()) as Artifact;
       setArtifacts((current) =>
         current.map((item) =>
@@ -166,10 +196,12 @@ export default function ArtifactCatalog({
   }
 
   async function deleteArtifact(artifact: Artifact) {
-    const confirmed = window.confirm(
-      `Delete “${artifact.title}”? Its active derived data will no longer be available.`,
-    );
-    if (!confirmed) {
+    setMenuId(null);
+    if (
+      !window.confirm(
+        `Delete “${artifact.title}”? Its active derived data will no longer be available.`,
+      )
+    ) {
       return;
     }
     setBusyId(artifact.artifact_id);
@@ -179,12 +211,15 @@ export default function ArtifactCatalog({
         `${getBackendUrl()}/artifacts/${artifact.artifact_id}`,
         { method: "DELETE", credentials: "include" },
       );
-      if (!response.ok) {
-        throw new Error("Artifact could not be deleted.");
-      }
+      if (!response.ok) throw new Error("Artifact could not be deleted.");
       setArtifacts((current) =>
         current.filter((item) => item.artifact_id !== artifact.artifact_id),
       );
+      if (artifact.kind === "shipment_dataset") {
+        setDataStatus((current) =>
+          current ? { ...current, shipment_count: 0 } : current,
+        );
+      }
       setStatusMessage(`Deleted ${artifact.title}.`);
       await onDeleted(artifact.kind);
     } catch (requestError) {
@@ -199,6 +234,7 @@ export default function ArtifactCatalog({
   }
 
   async function downloadArtifact(artifact: Artifact) {
+    setMenuId(null);
     setBusyId(artifact.artifact_id);
     setError(null);
     try {
@@ -221,7 +257,7 @@ export default function ArtifactCatalog({
       link.click();
       link.remove();
       URL.revokeObjectURL(objectUrl);
-      setStatusMessage(`Downloaded retained source for ${artifact.title}.`);
+      setStatusMessage(`Downloaded source for ${artifact.title}.`);
     } catch (requestError) {
       setError(
         requestError instanceof Error
@@ -238,6 +274,7 @@ export default function ArtifactCatalog({
     filename: string,
     label: string,
   ) {
+    setBusyExport(path);
     setError(null);
     try {
       const response = await fetch(`${getBackendUrl()}${path}`, {
@@ -259,58 +296,67 @@ export default function ArtifactCatalog({
           ? requestError.message
           : `${label} could not be downloaded.`,
       );
+    } finally {
+      setBusyExport(null);
     }
   }
 
   return (
-    <section
-      id="artifacts"
-      className="rounded-xl border border-border bg-card p-5 sm:p-6"
-    >
-      <div className="flex flex-wrap items-end justify-between gap-3">
+    <section id="artifacts" className="rounded-xl border border-border bg-card">
+      <div className="flex flex-wrap items-end justify-between gap-3 border-b border-border p-5 sm:px-6">
         <div>
-          <h2 className="text-2xl font-semibold text-primary">
+          <h2 className="text-xl font-semibold text-primary">
             Files & reports
           </h2>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
             Uploaded sources and saved outputs in this workspace.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={() =>
-              void downloadWorkspaceExport(
-                "/shipments/export",
-                "carbonsage-shipments.csv",
-                "Shipment data",
-              )
-            }
-            className="rounded-full border border-border px-3 py-2 text-xs font-semibold text-primary transition hover:border-accent"
-          >
-            Download shipments
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              void downloadWorkspaceExport(
-                "/suppliers/export",
-                "carbonsage-suppliers.csv",
-                "Supplier data",
-              )
-            }
-            className="rounded-full border border-border px-3 py-2 text-xs font-semibold text-primary transition hover:border-accent"
-          >
-            Download suppliers
-          </button>
-          <span className="text-sm text-muted-foreground">
-            {isLoading ? "Loading…" : `${artifacts.length} active`}
-          </span>
-        </div>
+        {!isLoading ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {dataStatus?.shipment_count ? (
+              <button
+                type="button"
+                onClick={() =>
+                  void downloadWorkspaceExport(
+                    "/shipments/export",
+                    "carbonsage-shipments.csv",
+                    "Shipment data",
+                  )
+                }
+                disabled={busyExport === "/shipments/export"}
+                className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-xs font-semibold text-primary transition hover:bg-muted disabled:opacity-60"
+              >
+                {busyExport === "/shipments/export" ? <Spinner /> : null}
+                Download shipments
+              </button>
+            ) : null}
+            {dataStatus?.supplier_count ? (
+              <button
+                type="button"
+                onClick={() =>
+                  void downloadWorkspaceExport(
+                    "/suppliers/export",
+                    "carbonsage-suppliers.csv",
+                    "Supplier data",
+                  )
+                }
+                disabled={busyExport === "/suppliers/export"}
+                className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-xs font-semibold text-primary transition hover:bg-muted disabled:opacity-60"
+              >
+                {busyExport === "/suppliers/export" ? <Spinner /> : null}
+                Download suppliers
+              </button>
+            ) : null}
+            <span className="text-xs text-muted-foreground">
+              {artifacts.length} active
+            </span>
+          </div>
+        ) : null}
       </div>
 
       {error ? (
-        <p className="mt-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
+        <p className="mx-5 mt-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800 sm:mx-6">
           {error}
         </p>
       ) : null}
@@ -319,152 +365,216 @@ export default function ArtifactCatalog({
       </p>
 
       {isLoading ? (
-        <p className="mt-5 text-sm text-muted-foreground">Loading files…</p>
+        <LoadingState label="Loading artifacts" />
       ) : artifacts.length === 0 ? (
-        <p className="mt-5 rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
-          No active artifacts yet. Upload shipment data or supplier evidence to
-          create the first workspace artifact.
+        <p className="m-5 rounded-lg border border-dashed border-border bg-background p-4 text-sm text-muted-foreground sm:m-6">
+          No active artifacts yet. Load demo data or upload shipment and
+          supplier sources to begin.
         </p>
       ) : (
-        <div className="mt-5 grid gap-4 xl:grid-cols-2">
+        <div className="divide-y divide-border">
           {artifacts.map((artifact) => {
             const sourceRetention = sourceRetentionFor(artifact);
+            const expanded = expandedId === artifact.artifact_id;
+            const sourceAvailable =
+              sourceRetention?.status === "retained" ||
+              artifact.source_type === "generated";
             return (
               <article
                 key={artifact.artifact_id}
                 id={`artifact-${artifact.artifact_id}`}
-                className={`min-w-0 rounded-lg border bg-background p-4 transition ${
+                className={`relative transition ${
                   focusedArtifactId === artifact.artifact_id
-                    ? "border-accent ring-2 ring-accent/20"
-                    : "border-border"
+                    ? "bg-accent/5 ring-1 ring-inset ring-accent/25"
+                    : "bg-card"
                 }`}
               >
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-accent">
-                      {kindLabels[artifact.kind]}
-                    </p>
-                    <h3 className="mt-1 break-words font-semibold text-primary">
-                      {artifact.title}
-                    </h3>
-                  </div>
-                  <span className="rounded-full bg-secondary/10 px-2 py-1 text-xs font-semibold capitalize text-primary">
-                    {artifact.status}
-                  </span>
-                </div>
-
-                <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
-                  <div>
-                    <dt className="text-xs text-muted-foreground">Source</dt>
-                    <dd className="break-words text-primary">
+                <div className="flex items-stretch">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setExpandedId((current) =>
+                        current === artifact.artifact_id
+                          ? null
+                          : artifact.artifact_id,
+                      )
+                    }
+                    aria-expanded={expanded}
+                    className="grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-5 py-4 text-left sm:px-6 md:grid-cols-[minmax(0,1.5fr)_0.7fr_0.8fr_auto]"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-accent">
+                        {kindLabels[artifact.kind]}
+                      </p>
+                      <h3 className="mt-1 break-words text-sm font-semibold text-primary md:truncate">
+                        {artifact.title}
+                      </h3>
+                    </div>
+                    <span className="hidden text-xs text-muted-foreground md:block">
                       {sourceLabels[artifact.source_type]}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-xs text-muted-foreground">Created</dt>
-                    <dd className="text-primary">
+                    </span>
+                    <span className="hidden text-xs text-muted-foreground md:block">
                       {new Intl.DateTimeFormat(undefined, {
                         dateStyle: "medium",
-                        timeStyle: "short",
                       }).format(new Date(artifact.created_at))}
-                    </dd>
-                  </div>
-                </dl>
-
-                <details className="mt-4 text-sm text-muted-foreground">
-                  <summary className="cursor-pointer font-semibold text-primary">
-                    Source details
-                  </summary>
-                  <dl className="mt-3 space-y-2">
-                    <div>
-                      <dt className="text-xs">Source reference</dt>
-                      <dd className="break-words">
-                        {artifact.source_reference ?? "Generated in workspace"}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs">Version</dt>
-                      <dd>{artifact.version}</dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs">Source retention</dt>
-                      <dd>
-                        {sourceRetention?.status === "retained" &&
-                        sourceRetention.expires_at
-                          ? `Private until ${new Intl.DateTimeFormat(
-                              undefined,
-                              {
-                                dateStyle: "medium",
-                                timeStyle: "short",
-                              },
-                            ).format(new Date(sourceRetention.expires_at))}`
-                          : "Not retained in this environment"}
-                      </dd>
-                    </div>
-                  </dl>
-                </details>
-
-                {editingId === artifact.artifact_id ? (
-                  <div className="mt-4 flex flex-wrap items-end gap-2">
-                    <label className="flex min-w-0 flex-1 flex-col gap-1 text-sm font-semibold text-primary">
-                      Artifact title
-                      <input
-                        value={draftTitle}
-                        onChange={(event) => setDraftTitle(event.target.value)}
-                        maxLength={255}
-                        className="min-w-0 rounded-lg border border-border bg-muted px-3 py-2 font-normal"
+                    </span>
+                    <span className="flex items-center gap-2">
+                      <span className="rounded-md bg-secondary/10 px-2 py-1 text-[11px] font-semibold capitalize text-secondary">
+                        {artifact.status}
+                      </span>
+                      <ChevronDown
+                        aria-hidden="true"
+                        className={`h-4 w-4 text-muted-foreground transition ${expanded ? "rotate-180" : ""}`}
                       />
-                    </label>
+                    </span>
+                  </button>
+
+                  <div className="relative flex items-center pr-4 sm:pr-5">
                     <button
                       type="button"
-                      onClick={() => renameArtifact(artifact)}
-                      disabled={busyId === artifact.artifact_id}
-                      className="rounded-full bg-secondary px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                      onClick={() =>
+                        setMenuId((current) =>
+                          current === artifact.artifact_id
+                            ? null
+                            : artifact.artifact_id,
+                        )
+                      }
+                      aria-label={`Actions for ${artifact.title}`}
+                      aria-expanded={menuId === artifact.artifact_id}
+                      className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-primary"
                     >
-                      Save name
+                      {busyId === artifact.artifact_id ? (
+                        <Spinner />
+                      ) : (
+                        <MoreHorizontal
+                          aria-hidden="true"
+                          className="h-4 w-4"
+                        />
+                      )}
                     </button>
-                    <button
-                      type="button"
-                      onClick={() => setEditingId(null)}
-                      className="rounded-full border border-border px-4 py-2 text-sm font-semibold text-primary"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                ) : (
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    {sourceRetention?.status === "retained" ||
-                    artifact.source_type === "generated" ? (
-                      <button
-                        type="button"
-                        onClick={() => downloadArtifact(artifact)}
-                        disabled={busyId === artifact.artifact_id}
-                        className="rounded-full bg-secondary px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
-                      >
-                        Download source
-                      </button>
+                    {menuId === artifact.artifact_id ? (
+                      <div className="absolute right-4 top-12 z-20 w-44 rounded-lg border border-border bg-card p-1.5 shadow-xl">
+                        <button
+                          type="button"
+                          onClick={() => void downloadArtifact(artifact)}
+                          disabled={!sourceAvailable}
+                          title={
+                            sourceAvailable
+                              ? undefined
+                              : "Source bytes are not retained in this environment."
+                          }
+                          className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-primary hover:bg-muted disabled:cursor-not-allowed disabled:text-muted-foreground disabled:opacity-55"
+                        >
+                          <Download aria-hidden="true" className="h-4 w-4" />
+                          Download source
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setExpandedId(artifact.artifact_id);
+                            setEditingId(artifact.artifact_id);
+                            setDraftTitle(artifact.title);
+                            setMenuId(null);
+                            setError(null);
+                          }}
+                          className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-primary hover:bg-muted"
+                        >
+                          <Pencil aria-hidden="true" className="h-4 w-4" />
+                          Rename
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void deleteArtifact(artifact)}
+                          className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-red-700 hover:bg-red-50"
+                        >
+                          <Trash2 aria-hidden="true" className="h-4 w-4" />
+                          Delete
+                        </button>
+                      </div>
                     ) : null}
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingId(artifact.artifact_id);
-                        setDraftTitle(artifact.title);
-                        setError(null);
-                      }}
-                      className="rounded-full border border-secondary px-4 py-2 text-sm font-semibold text-secondary"
-                    >
-                      Rename {artifact.title}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => deleteArtifact(artifact)}
-                      disabled={busyId === artifact.artifact_id}
-                      className="rounded-full border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 disabled:opacity-60"
-                    >
-                      Delete {artifact.title}
-                    </button>
                   </div>
-                )}
+                </div>
+
+                {expanded ? (
+                  <div className="border-t border-border bg-muted/35 px-5 py-4 sm:px-6">
+                    <dl className="grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                      <div>
+                        <dt className="text-xs text-muted-foreground">
+                          Source
+                        </dt>
+                        <dd className="mt-1 break-words text-primary">
+                          {artifact.source_reference ??
+                            "Generated in workspace"}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">Type</dt>
+                        <dd className="mt-1 text-primary">
+                          {sourceLabels[artifact.source_type]}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">
+                          Version
+                        </dt>
+                        <dd className="mt-1 text-primary">
+                          {artifact.version}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">
+                          Source retention
+                        </dt>
+                        <dd className="mt-1 text-primary">
+                          {sourceRetention?.status === "retained" &&
+                          sourceRetention.expires_at
+                            ? `Private until ${new Intl.DateTimeFormat(
+                                undefined,
+                                {
+                                  dateStyle: "medium",
+                                  timeStyle: "short",
+                                },
+                              ).format(new Date(sourceRetention.expires_at))}`
+                            : artifact.source_type === "generated"
+                              ? "Reproducible demo source"
+                              : "Not retained in this environment"}
+                        </dd>
+                      </div>
+                    </dl>
+
+                    {editingId === artifact.artifact_id ? (
+                      <div className="mt-4 flex flex-wrap items-end gap-2 border-t border-border pt-4">
+                        <label className="flex min-w-0 flex-1 flex-col gap-1.5 text-sm font-semibold text-primary">
+                          Artifact title
+                          <input
+                            value={draftTitle}
+                            onChange={(event) =>
+                              setDraftTitle(event.target.value)
+                            }
+                            maxLength={255}
+                            className="min-w-0 rounded-lg border border-border bg-card px-3 py-2 font-normal"
+                          />
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => void renameArtifact(artifact)}
+                          disabled={busyId === artifact.artifact_id}
+                          className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                        >
+                          {busyId === artifact.artifact_id ? <Spinner /> : null}
+                          Save
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setEditingId(null)}
+                          className="rounded-lg border border-border px-3.5 py-2 text-sm font-semibold text-primary"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
               </article>
             );
           })}

--- a/nzeroesg-client/app/dashboard/WorkspaceSectionPage.tsx
+++ b/nzeroesg-client/app/dashboard/WorkspaceSectionPage.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { X } from "lucide-react";
 
 import { getBackendUrl } from "@/app/api/urls";
+import { LoadingState, Spinner } from "@/app/components/Spinner";
 import ArtifactCatalog, {
   type ArtifactKind,
 } from "@/app/dashboard/ArtifactCatalog";
@@ -177,7 +178,13 @@ export function WorkspaceSectionPage({
   const [shipmentError, setShipmentError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
+  const [isLoadingShipments, setIsLoadingShipments] = useState(
+    section === "shipments" || section === "scenarios",
+  );
   const [suppliers, setSuppliers] = useState<SupplierCard[]>([]);
+  const [isLoadingSuppliers, setIsLoadingSuppliers] = useState(
+    section === "evidence",
+  );
   const [evidenceMatches, setEvidenceMatches] = useState<EvidenceMatch[]>([]);
   const [supplierName, setSupplierName] = useState("");
   const [supplierRegion, setSupplierRegion] = useState("");
@@ -219,6 +226,9 @@ export function WorkspaceSectionPage({
         if (isCurrent) {
           setShipmentError("Shipment data could not be loaded from the API.");
         }
+      })
+      .finally(() => {
+        if (isCurrent) setIsLoadingShipments(false);
       });
 
     return () => {
@@ -228,6 +238,7 @@ export function WorkspaceSectionPage({
 
   useEffect(() => {
     if (section !== "evidence") return;
+    let isCurrent = true;
     fetch(`${getBackendUrl()}/suppliers`, { credentials: "include" })
       .then(async (response) => {
         if (!response.ok) {
@@ -235,10 +246,22 @@ export function WorkspaceSectionPage({
         }
         return (await response.json()) as { suppliers: SupplierCard[] };
       })
-      .then((payload) => setSuppliers(payload.suppliers))
-      .catch(() =>
-        setEvidenceError("Supplier evidence could not be loaded from the API."),
-      );
+      .then((payload) => {
+        if (isCurrent) setSuppliers(payload.suppliers);
+      })
+      .catch(() => {
+        if (isCurrent) {
+          setEvidenceError(
+            "Supplier evidence could not be loaded from the API.",
+          );
+        }
+      })
+      .finally(() => {
+        if (isCurrent) setIsLoadingSuppliers(false);
+      });
+    return () => {
+      isCurrent = false;
+    };
   }, [section, session.workspace_id]);
 
   function selectShipmentFile(event: ChangeEvent<HTMLInputElement>) {
@@ -497,7 +520,7 @@ export function WorkspaceSectionPage({
               setEvidenceError(null);
               setIsSupplierModalOpen(true);
             }}
-            className="rounded-full bg-secondary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent"
+            className="rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent"
           >
             Add supplier
           </button>
@@ -505,7 +528,7 @@ export function WorkspaceSectionPage({
         {section === "shipments" ? (
           <Link
             href="/dashboard/agent"
-            className="rounded-full bg-secondary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-accent"
+            className="rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent"
           >
             Calculate freight
           </Link>
@@ -666,9 +689,10 @@ export function WorkspaceSectionPage({
               <button
                 type="submit"
                 disabled={isUploading}
-                className="rounded-full bg-secondary px-5 py-3 font-semibold text-white transition hover:bg-accent disabled:cursor-wait disabled:opacity-60"
+                className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent disabled:cursor-wait disabled:opacity-60"
               >
-                {isUploading ? "Analyzing…" : "Upload and analyze"}
+                {isUploading ? <Spinner /> : null}
+                Upload and analyze
               </button>
             </form>
             <p className="mt-3 text-xs text-muted-foreground">
@@ -682,11 +706,17 @@ export function WorkspaceSectionPage({
             </p>
           ) : null}
 
-          {shipmentData ? (
+          {isLoadingShipments ? (
+            <LoadingState label="Loading shipment data" />
+          ) : shipmentData ? (
             <>
               {shipmentData.errors.length > 0 ? (
                 <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
-                  <p className="font-semibold">Data-quality issues</p>
+                  <p className="font-semibold">
+                    {shipmentData.accepted_rows === 0
+                      ? "We couldn’t import this file"
+                      : "Some rows need attention"}
+                  </p>
                   <ul className="mt-2 list-disc space-y-1 pl-5">
                     {shipmentData.errors.slice(0, 8).map((issue, index) => (
                       <li key={`${issue.row_number}-${issue.field}-${index}`}>
@@ -699,167 +729,173 @@ export function WorkspaceSectionPage({
                 </div>
               ) : null}
 
-              <div className="mt-6 grid gap-6 lg:grid-cols-2">
-                <div>
-                  <h3 className="font-semibold text-primary">
-                    Emissions by mode
-                  </h3>
-                  <div
-                    className="mt-3 space-y-3"
-                    aria-label="Emissions by freight mode"
-                  >
-                    {modeBreakdown.map(([mode, breakdown]) => (
-                      <div key={mode}>
-                        <div className="mb-1 flex justify-between text-sm text-muted-foreground">
-                          <span className="font-semibold capitalize text-primary">
-                            {mode}
-                          </span>
-                          <span>
-                            {breakdown.emissions_kg.toFixed(2)} kg ·{" "}
-                            {breakdown.shipment_count} shipments
-                          </span>
-                        </div>
-                        <div className="h-3 rounded-full bg-border">
-                          <div
-                            className="h-3 rounded-full bg-secondary"
-                            style={{
-                              width: `${Math.min(
-                                100,
-                                (breakdown.emissions_kg / maxModeEmissions) *
-                                  100,
-                              )}%`,
-                            }}
-                          />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                  <table className="sr-only">
-                    <caption>Emissions by freight mode</caption>
-                    <thead>
-                      <tr>
-                        <th>Mode</th>
-                        <th>Emissions kg</th>
-                        <th>Shipments</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {modeBreakdown.map(([mode, breakdown]) => (
-                        <tr key={mode}>
-                          <td>{mode}</td>
-                          <td>{breakdown.emissions_kg}</td>
-                          <td>{breakdown.shipment_count}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-                <div>
-                  <h3 className="font-semibold text-primary">
-                    Top shipment hotspots
-                  </h3>
-                  <div
-                    className="mt-3 space-y-3"
-                    aria-label="Top shipment emissions hotspots"
-                  >
-                    {hotspotRows.map((hotspot) => (
-                      <div key={hotspot.shipment_id}>
-                        <div className="mb-1 flex justify-between gap-3 text-sm">
-                          <span className="text-primary">
-                            <strong>{hotspot.shipment_id}</strong>
-                            <span className="ml-2 text-muted-foreground">
-                              {hotspot.origin} → {hotspot.destination}
-                            </span>
-                          </span>
-                          <span className="font-semibold text-primary">
-                            {hotspot.emissions_kg.toFixed(2)} kg
-                          </span>
-                        </div>
-                        <div className="h-3 rounded-full bg-border">
-                          <div
-                            className="h-3 rounded-full bg-accent"
-                            style={{
-                              width: `${Math.min(
-                                100,
-                                (hotspot.emissions_kg / maxHotspotEmissions) *
-                                  100,
-                              )}%`,
-                            }}
-                          />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                  <table className="sr-only">
-                    <caption>Top shipment emissions hotspots</caption>
-                    <thead>
-                      <tr>
-                        <th>Shipment</th>
-                        <th>Route</th>
-                        <th>Emissions kg</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {hotspotRows.map((hotspot) => (
-                        <tr key={hotspot.shipment_id}>
-                          <td>{hotspot.shipment_id}</td>
-                          <td>
-                            {hotspot.origin} → {hotspot.destination}
-                          </td>
-                          <td>{hotspot.emissions_kg}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-
-              <div className="mt-6 overflow-x-auto rounded-lg border border-border bg-background">
-                <table className="min-w-full text-left text-sm">
-                  <caption className="sr-only">
-                    Normalized shipment rows
-                  </caption>
-                  <thead className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
-                    <tr>
-                      <th className="px-4 py-3">Shipment</th>
-                      <th className="px-4 py-3">Route</th>
-                      <th className="px-4 py-3">Weight</th>
-                      <th className="px-4 py-3">Distance</th>
-                      <th className="px-4 py-3">Mode</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {shipmentData.rows.slice(0, 10).map((row) => (
-                      <tr
-                        key={`${row.shipment_id}-${row.source_row}`}
-                        className="border-b border-border last:border-0"
+              {shipmentData.accepted_rows > 0 ? (
+                <>
+                  <div className="mt-6 grid gap-6 lg:grid-cols-2">
+                    <div>
+                      <h3 className="font-semibold text-primary">
+                        Emissions by mode
+                      </h3>
+                      <div
+                        className="mt-3 space-y-3"
+                        aria-label="Emissions by freight mode"
                       >
-                        <td className="px-4 py-3 font-semibold text-primary">
-                          {row.shipment_id}
-                        </td>
-                        <td className="px-4 py-3 text-muted-foreground">
-                          {row.origin} → {row.destination}
-                        </td>
-                        <td className="px-4 py-3 text-muted-foreground">
-                          {row.weight_kg} kg
-                        </td>
-                        <td className="px-4 py-3 text-muted-foreground">
-                          {row.distance_km} km
-                        </td>
-                        <td className="px-4 py-3 capitalize text-primary">
-                          {row.transport_method}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+                        {modeBreakdown.map(([mode, breakdown]) => (
+                          <div key={mode}>
+                            <div className="mb-1 flex justify-between text-sm text-muted-foreground">
+                              <span className="font-semibold capitalize text-primary">
+                                {mode}
+                              </span>
+                              <span>
+                                {breakdown.emissions_kg.toFixed(2)} kg ·{" "}
+                                {breakdown.shipment_count} shipments
+                              </span>
+                            </div>
+                            <div className="h-3 rounded-full bg-border">
+                              <div
+                                className="h-3 rounded-full bg-secondary"
+                                style={{
+                                  width: `${Math.min(
+                                    100,
+                                    (breakdown.emissions_kg /
+                                      maxModeEmissions) *
+                                      100,
+                                  )}%`,
+                                }}
+                              />
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                      <table className="sr-only">
+                        <caption>Emissions by freight mode</caption>
+                        <thead>
+                          <tr>
+                            <th>Mode</th>
+                            <th>Emissions kg</th>
+                            <th>Shipments</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {modeBreakdown.map(([mode, breakdown]) => (
+                            <tr key={mode}>
+                              <td>{mode}</td>
+                              <td>{breakdown.emissions_kg}</td>
+                              <td>{breakdown.shipment_count}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    <div>
+                      <h3 className="font-semibold text-primary">
+                        Top shipment hotspots
+                      </h3>
+                      <div
+                        className="mt-3 space-y-3"
+                        aria-label="Top shipment emissions hotspots"
+                      >
+                        {hotspotRows.map((hotspot) => (
+                          <div key={hotspot.shipment_id}>
+                            <div className="mb-1 flex justify-between gap-3 text-sm">
+                              <span className="text-primary">
+                                <strong>{hotspot.shipment_id}</strong>
+                                <span className="ml-2 text-muted-foreground">
+                                  {hotspot.origin} → {hotspot.destination}
+                                </span>
+                              </span>
+                              <span className="font-semibold text-primary">
+                                {hotspot.emissions_kg.toFixed(2)} kg
+                              </span>
+                            </div>
+                            <div className="h-3 rounded-full bg-border">
+                              <div
+                                className="h-3 rounded-full bg-accent"
+                                style={{
+                                  width: `${Math.min(
+                                    100,
+                                    (hotspot.emissions_kg /
+                                      maxHotspotEmissions) *
+                                      100,
+                                  )}%`,
+                                }}
+                              />
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                      <table className="sr-only">
+                        <caption>Top shipment emissions hotspots</caption>
+                        <thead>
+                          <tr>
+                            <th>Shipment</th>
+                            <th>Route</th>
+                            <th>Emissions kg</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {hotspotRows.map((hotspot) => (
+                            <tr key={hotspot.shipment_id}>
+                              <td>{hotspot.shipment_id}</td>
+                              <td>
+                                {hotspot.origin} → {hotspot.destination}
+                              </td>
+                              <td>{hotspot.emissions_kg}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
 
-              <p className="mt-4 text-xs leading-5 text-muted-foreground">
-                Factor source: {shipmentData.analysis.factor_source} · version{" "}
-                {shipmentData.analysis.factor_version}.{" "}
-                {shipmentData.analysis.factor_applicability}
-              </p>
+                  <div className="mt-6 overflow-x-auto rounded-lg border border-border bg-background">
+                    <table className="min-w-full text-left text-sm">
+                      <caption className="sr-only">
+                        Normalized shipment rows
+                      </caption>
+                      <thead className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+                        <tr>
+                          <th className="px-4 py-3">Shipment</th>
+                          <th className="px-4 py-3">Route</th>
+                          <th className="px-4 py-3">Weight</th>
+                          <th className="px-4 py-3">Distance</th>
+                          <th className="px-4 py-3">Mode</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {shipmentData.rows.slice(0, 10).map((row) => (
+                          <tr
+                            key={`${row.shipment_id}-${row.source_row}`}
+                            className="border-b border-border last:border-0"
+                          >
+                            <td className="px-4 py-3 font-semibold text-primary">
+                              {row.shipment_id}
+                            </td>
+                            <td className="px-4 py-3 text-muted-foreground">
+                              {row.origin} → {row.destination}
+                            </td>
+                            <td className="px-4 py-3 text-muted-foreground">
+                              {row.weight_kg} kg
+                            </td>
+                            <td className="px-4 py-3 text-muted-foreground">
+                              {row.distance_km} km
+                            </td>
+                            <td className="px-4 py-3 capitalize text-primary">
+                              {row.transport_method}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <p className="mt-4 text-xs leading-5 text-muted-foreground">
+                    Factor source: {shipmentData.analysis.factor_source} ·
+                    version {shipmentData.analysis.factor_version}.{" "}
+                    {shipmentData.analysis.factor_applicability}
+                  </p>
+                </>
+              ) : null}
             </>
           ) : null}
         </section>
@@ -956,9 +992,10 @@ export function WorkspaceSectionPage({
                   <button
                     type="submit"
                     disabled={isEvidenceUploading}
-                    className="rounded-full bg-secondary px-5 py-3 font-semibold text-white transition hover:bg-accent disabled:cursor-wait disabled:opacity-60"
+                    className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent disabled:cursor-wait disabled:opacity-60"
                   >
-                    {isEvidenceUploading ? "Saving…" : "Add supplier"}
+                    {isEvidenceUploading ? <Spinner /> : null}
+                    Add supplier
                   </button>
                   <span className="ml-3 text-xs text-muted-foreground">
                     Attached documents: max 10 MB
@@ -976,7 +1013,9 @@ export function WorkspaceSectionPage({
 
           <div className="order-4 mt-7">
             <h3 className="font-semibold text-primary">Supplier cards</h3>
-            {suppliers.length === 0 ? (
+            {isLoadingSuppliers ? (
+              <LoadingState label="Loading suppliers" />
+            ) : suppliers.length === 0 ? (
               <p className="mt-3 text-sm text-muted-foreground">
                 No suppliers have been added to this workspace.
               </p>
@@ -1062,9 +1101,10 @@ export function WorkspaceSectionPage({
               <button
                 type="submit"
                 disabled={isSearchingEvidence}
-                className="rounded-full border border-secondary px-5 py-2 font-semibold text-secondary transition hover:bg-secondary hover:text-white disabled:cursor-wait disabled:opacity-60"
+                className="inline-flex items-center gap-2 rounded-lg border border-secondary px-3.5 py-2 text-sm font-semibold text-secondary transition hover:bg-secondary hover:text-white disabled:cursor-wait disabled:opacity-60"
               >
-                {isSearchingEvidence ? "Searching…" : "Search citations"}
+                {isSearchingEvidence ? <Spinner /> : null}
+                Search citations
               </button>
             </div>
           </form>
@@ -1155,9 +1195,10 @@ export function WorkspaceSectionPage({
               disabled={
                 isRunningScenario || !shipmentData?.analysis.shipment_count
               }
-              className="rounded-full bg-secondary px-5 py-3 font-semibold text-white transition hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isRunningScenario ? "Comparing…" : "Run scenario"}
+              {isRunningScenario ? <Spinner /> : null}
+              Run scenario
             </button>
           </form>
 

--- a/nzeroesg-client/app/dashboard/WorkspaceShell.tsx
+++ b/nzeroesg-client/app/dashboard/WorkspaceShell.tsx
@@ -14,7 +14,8 @@ import { usePathname, useRouter } from "next/navigation";
 import {
   Building2,
   ChartNoAxesCombined,
-  ChevronUp,
+  ChevronDown,
+  CircleHelp,
   Files,
   LayoutDashboard,
   Leaf,
@@ -28,6 +29,7 @@ import {
 } from "lucide-react";
 
 import { getBackendUrl } from "@/app/api/urls";
+import { LoadingState } from "@/app/components/Spinner";
 import ChatInterface from "@/app/components/chat_ui/ChatInterface";
 import { runWorkspaceAgentAction } from "@/app/dashboard/agent-actions";
 import { useTheme } from "@/app/utils/contexts/ThemeContext";
@@ -46,25 +48,30 @@ type WorkspaceContextValue = {
   refreshSession: () => Promise<void>;
 };
 
+type NavigationItem = {
+  label: string;
+  href: string;
+  icon: typeof Leaf;
+};
+
 const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
 
-const navigation = [
+const workspaceNavigation: NavigationItem[] = [
   {
     label: "Ask CarbonSage",
     href: "/dashboard/agent",
     icon: MessageSquareText,
   },
-  { label: "Integrations", href: "/dashboard/integrations", icon: Plug },
   { label: "Overview", href: "/dashboard/overview", icon: LayoutDashboard },
+  { label: "Integrations", href: "/dashboard/integrations", icon: Plug },
   { label: "Artifacts", href: "/dashboard/artifacts", icon: Files },
-  { label: "Shipments", href: "/dashboard/shipments", icon: Truck },
-  {
-    label: "Suppliers",
-    href: "/dashboard/evidence",
-    icon: Building2,
-  },
-  { label: "Scenarios", href: "/dashboard/scenarios", icon: Route },
   { label: "Report", href: "/dashboard/report", icon: ChartNoAxesCombined },
+];
+
+const simulationNavigation: NavigationItem[] = [
+  { label: "Shipments", href: "/dashboard/shipments", icon: Truck },
+  { label: "Suppliers", href: "/dashboard/evidence", icon: Building2 },
+  { label: "Scenarios", href: "/dashboard/scenarios", icon: Route },
 ];
 
 export function useWorkspace() {
@@ -75,6 +82,34 @@ export function useWorkspace() {
   return value;
 }
 
+function NavigationLink({
+  item,
+  pathname,
+  onNavigate,
+}: {
+  item: NavigationItem;
+  pathname: string;
+  onNavigate: () => void;
+}) {
+  const Icon = item.icon;
+  const active = pathname.startsWith(item.href);
+  return (
+    <Link
+      href={item.href}
+      onClick={onNavigate}
+      aria-current={active ? "page" : undefined}
+      className={`inline-flex shrink-0 items-center gap-2.5 rounded-md px-2.5 py-2 text-[13px] transition lg:flex ${
+        active
+          ? "bg-secondary/10 font-semibold text-secondary"
+          : "text-muted-foreground hover:bg-card hover:text-primary"
+      }`}
+    >
+      <Icon aria-hidden="true" className="h-4 w-4" />
+      {item.label}
+    </Link>
+  );
+}
+
 export default function WorkspaceShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
@@ -82,6 +117,7 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<WorkspaceSession | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [profileOpen, setProfileOpen] = useState(false);
+  const [simulationsOpen, setSimulationsOpen] = useState(true);
   const profileRef = useRef<HTMLDivElement>(null);
 
   const refreshSession = useCallback(async () => {
@@ -166,30 +202,32 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
 
   if (!session) {
     return (
-      <main className="flex min-h-screen items-center justify-center text-muted-foreground">
-        Loading private workspace…
+      <main className="flex min-h-screen items-center justify-center">
+        <LoadingState label="Loading private workspace" />
       </main>
     );
   }
 
+  const allNavigation = [...workspaceNavigation, ...simulationNavigation];
+
   return (
     <WorkspaceContext.Provider value={{ session, refreshSession }}>
-      <div className="mx-auto flex min-h-screen w-full max-w-[100rem] flex-col overflow-x-clip lg:flex-row">
-        <aside className="sticky top-0 z-40 flex border-b border-border bg-card/95 px-4 py-4 backdrop-blur lg:h-screen lg:w-72 lg:shrink-0 lg:flex-col lg:overflow-y-auto lg:border-b-0 lg:border-r lg:px-6 lg:py-7">
+      <div className="flex min-h-screen w-full flex-col overflow-x-clip bg-background lg:flex-row">
+        <aside className="sticky top-0 z-40 flex border-b border-sidebar-border bg-sidebar px-4 py-3 lg:h-screen lg:w-64 lg:shrink-0 lg:flex-col lg:overflow-y-auto lg:border-b-0 lg:border-r lg:px-4 lg:py-5">
           <div className="min-w-0 flex-1">
-            <div className="flex items-center justify-between gap-4 lg:block">
+            <div className="flex items-center justify-between gap-4 px-1">
               <div className="flex items-center gap-3">
-                <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-border bg-muted text-accent">
+                <span className="flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-card text-accent">
                   <Leaf aria-hidden="true" className="h-4 w-4" />
                 </span>
                 <div>
                   <Link
                     href="/"
-                    className="text-lg font-bold tracking-tight text-primary"
+                    className="text-base font-bold tracking-tight text-primary"
                   >
                     CarbonSage
                   </Link>
-                  <p className="text-xs text-muted-foreground">Workspace</p>
+                  <p className="text-[11px] text-muted-foreground">Workspace</p>
                 </div>
               </div>
               <button
@@ -203,42 +241,82 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
 
             <nav
               aria-label="Workspace navigation"
-              className="mt-4 flex gap-2 overflow-x-auto pb-1 lg:mt-8 lg:block lg:space-y-1 lg:overflow-visible lg:pb-0"
+              className="mt-3 flex gap-1.5 overflow-x-auto pb-1 lg:hidden"
             >
-              {navigation.map((item) => {
-                const Icon = item.icon;
-                const active =
-                  item.href === "/dashboard"
-                    ? pathname === item.href
-                    : pathname.startsWith(item.href);
-                return (
-                  <Link
-                    href={item.href}
+              {allNavigation.map((item) => (
+                <NavigationLink
+                  key={item.href}
+                  item={item}
+                  pathname={pathname}
+                  onNavigate={() => setProfileOpen(false)}
+                />
+              ))}
+            </nav>
+
+            <nav
+              aria-label="Workspace navigation"
+              className="mt-7 hidden lg:block"
+            >
+              <p className="px-2.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/80">
+                Workspace
+              </p>
+              <div className="mt-1.5 space-y-0.5">
+                {workspaceNavigation.map((item) => (
+                  <NavigationLink
                     key={item.href}
-                    onClick={() => setProfileOpen(false)}
-                    aria-current={active ? "page" : undefined}
-                    className={`inline-flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm transition lg:flex ${
-                      active
-                        ? "bg-primary font-semibold text-background"
-                        : "text-muted-foreground hover:bg-muted hover:text-primary"
-                    }`}
-                  >
-                    <Icon aria-hidden="true" className="h-4 w-4" />
-                    {item.label}
-                  </Link>
-                );
-              })}
+                    item={item}
+                    pathname={pathname}
+                    onNavigate={() => setProfileOpen(false)}
+                  />
+                ))}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setSimulationsOpen((current) => !current)}
+                aria-expanded={simulationsOpen}
+                className="mt-6 flex w-full items-center justify-between px-2.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/80"
+              >
+                Simulations
+                <ChevronDown
+                  aria-hidden="true"
+                  className={`h-3.5 w-3.5 transition ${simulationsOpen ? "rotate-180" : ""}`}
+                />
+              </button>
+              {simulationsOpen ? (
+                <div className="mt-1.5 space-y-0.5">
+                  {simulationNavigation.map((item) => (
+                    <NavigationLink
+                      key={item.href}
+                      item={item}
+                      pathname={pathname}
+                      onNavigate={() => setProfileOpen(false)}
+                    />
+                  ))}
+                </div>
+              ) : null}
             </nav>
           </div>
 
-          <div ref={profileRef} className="relative mt-6 hidden lg:block">
+          <div ref={profileRef} className="relative mt-5 hidden lg:block">
             {profileOpen ? (
-              <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-border bg-card p-2 shadow-xl">
+              <div className="absolute bottom-full left-0 mb-2 w-52 overflow-hidden rounded-xl border border-border bg-card p-1.5 shadow-xl">
+                <Link
+                  href="/dashboard/how-to"
+                  onClick={() => setProfileOpen(false)}
+                  className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm text-primary transition hover:bg-muted"
+                >
+                  <CircleHelp
+                    aria-hidden="true"
+                    className="h-4 w-4 text-accent"
+                  />
+                  How to use CarbonSage
+                </Link>
                 <button
                   type="button"
                   onClick={toggleTheme}
                   disabled={!mounted}
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-primary transition hover:bg-muted disabled:opacity-50"
+                  className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm text-primary transition hover:bg-muted disabled:opacity-50"
                 >
                   {theme === "dark" ? (
                     <Sun aria-hidden="true" className="h-4 w-4 text-accent" />
@@ -250,7 +328,7 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
                 <button
                   type="button"
                   onClick={leaveWorkspace}
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-primary transition hover:bg-muted"
+                  className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm text-primary transition hover:bg-muted"
                 >
                   <LogOut aria-hidden="true" className="h-4 w-4 text-accent" />
                   Sign out
@@ -260,24 +338,11 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
             <button
               type="button"
               onClick={() => setProfileOpen((current) => !current)}
+              aria-label="Open workspace menu"
               aria-expanded={profileOpen}
-              className="flex w-full items-center gap-3 rounded-xl border border-border bg-background p-3 text-left transition hover:border-accent"
+              className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-sm font-bold text-white shadow-sm transition hover:bg-accent"
             >
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-secondary text-sm font-bold text-white">
-                DW
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-semibold text-primary">
-                  Demo Workspace
-                </span>
-                <span className="block text-xs text-muted-foreground">
-                  Temporary session
-                </span>
-              </span>
-              <ChevronUp
-                aria-hidden="true"
-                className={`h-4 w-4 text-muted-foreground transition ${profileOpen ? "rotate-180" : ""}`}
-              />
+              DW
             </button>
           </div>
         </aside>

--- a/nzeroesg-client/app/dashboard/how-to/page.tsx
+++ b/nzeroesg-client/app/dashboard/how-to/page.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+import {
+  Bot,
+  Database,
+  Download,
+  FileSearch,
+  SlidersHorizontal,
+  Upload,
+} from "lucide-react";
+
+const steps = [
+  {
+    title: "Choose your workspace data",
+    description:
+      "Load the fictional simulation dataset for a guided start, or bring CSV/XLSX shipment records and PDF/TXT supplier documents.",
+    icon: Database,
+  },
+  {
+    title: "Ask a decision question",
+    description:
+      "Ask CarbonSage about supplier claims, freight emissions, missing information, or a lower-emission alternative.",
+    icon: Bot,
+  },
+  {
+    title: "Inspect the evidence",
+    description:
+      "Open citations, exact chart values, calculation details, and source artifacts before carrying a result into a decision.",
+    icon: FileSearch,
+  },
+  {
+    title: "Explore the simulation views",
+    description:
+      "Use Shipments and Suppliers for normalized records and supporting detail. Scenario workflows will be added after the core agent journey is settled.",
+    icon: SlidersHorizontal,
+  },
+  {
+    title: "Export what you need",
+    description:
+      "Download available source artifacts, normalized workspace data, or a decision report for review outside CarbonSage.",
+    icon: Download,
+  },
+];
+
+export default function HowToPage() {
+  return (
+    <section className="px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-accent">
+          Workspace guide
+        </p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-primary sm:text-4xl">
+          How to use CarbonSage
+        </h1>
+        <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
+          Start with the agent, keep the source trail visible, and use the
+          workspace pages when you need to inspect or manage the underlying
+          information.
+        </p>
+      </header>
+
+      <div className="mt-8 divide-y divide-border rounded-xl border border-border bg-card">
+        {steps.map((step, index) => {
+          const Icon = step.icon;
+          return (
+            <article key={step.title} className="flex gap-4 p-5 sm:p-6">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-secondary/10 text-secondary">
+                <Icon aria-hidden="true" className="h-4 w-4" />
+              </span>
+              <div>
+                <p className="text-xs font-semibold text-muted-foreground">
+                  Step {index + 1}
+                </p>
+                <h2 className="mt-1 font-semibold text-primary">
+                  {step.title}
+                </h2>
+                <p className="mt-1.5 max-w-3xl text-sm leading-6 text-muted-foreground">
+                  {step.description}
+                </p>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 flex flex-wrap gap-2">
+        <Link
+          href="/dashboard/agent"
+          className="rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent"
+        >
+          Ask CarbonSage
+        </Link>
+        <Link
+          href="/dashboard/integrations"
+          className="inline-flex items-center gap-2 rounded-lg border border-border px-3.5 py-2 text-sm font-semibold text-primary transition hover:bg-muted"
+        >
+          <Upload aria-hidden="true" className="h-4 w-4" />
+          Choose data
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/nzeroesg-client/app/dashboard/integrations/page.tsx
+++ b/nzeroesg-client/app/dashboard/integrations/page.tsx
@@ -1,43 +1,176 @@
-import { Cloud, LockKeyhole } from "lucide-react";
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Cloud, Database, FileCheck2, LockKeyhole } from "lucide-react";
+
+import { getBackendUrl } from "@/app/api/urls";
+import { Spinner } from "@/app/components/Spinner";
+import { runWorkspaceAgentAction } from "@/app/dashboard/agent-actions";
+
+type DemoDataStatus = {
+  has_artifacts: boolean;
+  shipment_count: number;
+  supplier_count: number;
+  evidence_document_count: number;
+};
 
 export default function IntegrationsPage() {
+  const [demoData, setDemoData] = useState<DemoDataStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingDemoData, setIsLoadingDemoData] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshDemoData = useCallback(async () => {
+    const response = await fetch(`${getBackendUrl()}/demo/data`, {
+      credentials: "include",
+    });
+    if (!response.ok) throw new Error("Workspace data status is unavailable.");
+    setDemoData((await response.json()) as DemoDataStatus);
+  }, []);
+
+  useEffect(() => {
+    let isCurrent = true;
+    fetch(`${getBackendUrl()}/demo/data`, { credentials: "include" })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("Workspace data status is unavailable.");
+        }
+        return (await response.json()) as DemoDataStatus;
+      })
+      .then((payload) => {
+        if (isCurrent) setDemoData(payload);
+      })
+      .catch((requestError) => {
+        if (isCurrent) {
+          setError(
+            requestError instanceof Error
+              ? requestError.message
+              : "Workspace data status is unavailable.",
+          );
+        }
+      })
+      .finally(() => {
+        if (isCurrent) setIsLoading(false);
+      });
+    return () => {
+      isCurrent = false;
+    };
+  }, []);
+
+  async function loadDemoData() {
+    setIsLoadingDemoData(true);
+    setError(null);
+    try {
+      await runWorkspaceAgentAction("workspace.load_demo_data", null);
+      await refreshDemoData();
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "Demo simulation data could not be loaded.",
+      );
+    } finally {
+      setIsLoadingDemoData(false);
+    }
+  }
+
   return (
     <section className="px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
       <header>
         <h1 className="text-3xl font-bold tracking-tight text-primary sm:text-4xl">
           Integrations
         </h1>
-        <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
-          Bring approved source documents into CarbonSage without duplicating
-          your team&apos;s existing workflow.
+        <p className="mt-2 max-w-3xl leading-7 text-muted-foreground">
+          Bring supplier disclosures, spreadsheets, and shipment records into
+          one carbon-intelligence workspace. CarbonSage normalizes the useful
+          facts while preserving source identity for citations.
         </p>
       </header>
 
-      <article className="mt-7 max-w-2xl rounded-2xl border border-border bg-card p-6 sm:p-7">
-        <div className="flex items-start gap-4">
-          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-secondary">
-            <Cloud aria-hidden="true" className="h-5 w-5" />
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <h2 className="text-xl font-semibold text-primary">
-                Google Drive
-              </h2>
-              <span className="rounded-full border border-border bg-background px-3 py-1 text-xs font-semibold text-muted-foreground">
-                Coming soon
+      {error ? (
+        <p className="mt-5 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="mt-7 space-y-4">
+        <article className="w-full rounded-xl border border-border bg-card p-5 sm:p-6">
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-4">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-secondary/10 text-secondary">
+                <Database aria-hidden="true" className="h-5 w-5" />
               </span>
+              <div>
+                <h2 className="text-lg font-semibold text-primary">
+                  Demo simulation data
+                </h2>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+                  Load a fictional workspace with 24 supplier profiles, cited
+                  disclosures, and a mixed-mode shipment baseline. It can be
+                  removed at any time from Artifacts.
+                </p>
+                {demoData?.has_artifacts ? (
+                  <p className="mt-3 inline-flex items-center gap-2 text-xs font-medium text-secondary">
+                    <FileCheck2 aria-hidden="true" className="h-4 w-4" />
+                    {demoData.supplier_count} suppliers ·{" "}
+                    {demoData.shipment_count} shipments ·{" "}
+                    {demoData.evidence_document_count} cited documents
+                  </p>
+                ) : null}
+              </div>
             </div>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">
-              Select workspace files, preserve their source identity, and keep
-              retrieval permissions tied to the connected account.
-            </p>
-            <p className="mt-5 flex items-center gap-2 text-xs text-muted-foreground">
-              <LockKeyhole aria-hidden="true" className="h-4 w-4 text-accent" />
-              A connection will always require explicit authorization.
-            </p>
+            {isLoading ? (
+              <Spinner label="Checking demo data" className="h-5 w-5" />
+            ) : demoData?.has_artifacts ? (
+              <span className="shrink-0 rounded-md bg-secondary/10 px-2.5 py-1.5 text-xs font-semibold text-secondary">
+                Loaded
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void loadDemoData()}
+                disabled={isLoadingDemoData}
+                className="inline-flex shrink-0 items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent disabled:opacity-60"
+              >
+                {isLoadingDemoData ? <Spinner /> : null}
+                Load demo data
+              </button>
+            )}
           </div>
-        </div>
-      </article>
+        </article>
+
+        <article className="w-full rounded-xl border border-border bg-card p-5 sm:p-6">
+          <div className="flex items-start gap-4">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-secondary/10 text-secondary">
+              <Cloud aria-hidden="true" className="h-5 w-5" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="text-lg font-semibold text-primary">
+                  Google Drive
+                </h2>
+                <span className="rounded-md border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-muted-foreground">
+                  Coming soon
+                </span>
+              </div>
+              <p className="mt-3 max-w-4xl text-sm leading-6 text-muted-foreground">
+                Select supplier reports, audit evidence, spreadsheets, and
+                shipment files from Drive. Imported files will retain their
+                source identity so CarbonSage can cite the document behind a
+                normalized fact or recommendation.
+              </p>
+              <p className="mt-5 flex items-center gap-2 text-xs text-muted-foreground">
+                <LockKeyhole
+                  aria-hidden="true"
+                  className="h-4 w-4 text-accent"
+                />
+                A connection will require explicit account authorization and
+                selected-file access.
+              </p>
+            </div>
+          </div>
+        </article>
+      </div>
     </section>
   );
 }

--- a/nzeroesg-client/app/dashboard/report/page.tsx
+++ b/nzeroesg-client/app/dashboard/report/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { getBackendUrl } from "@/app/api/urls";
+import { LoadingState, Spinner } from "@/app/components/Spinner";
 
 type ModeBreakdown = {
   shipment_count: number;
@@ -207,30 +208,35 @@ export default function ReportPage() {
           type="button"
           onClick={refreshReport}
           disabled={isLoading}
-          className="rounded-full bg-secondary px-5 py-2.5 font-semibold text-white disabled:opacity-60"
+          className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white disabled:opacity-60"
         >
-          {isLoading ? "Refreshing…" : "Refresh report"}
+          {isLoading ? <Spinner /> : null}
+          Refresh report
         </button>
         <button
           type="button"
           onClick={saveSnapshot}
           disabled={isSaving || !report?.shipment_analysis.shipment_count}
-          className="rounded-full border border-secondary px-5 py-2.5 font-semibold text-secondary disabled:opacity-60"
+          className="inline-flex items-center gap-2 rounded-lg border border-secondary px-3.5 py-2 text-sm font-semibold text-secondary disabled:opacity-60"
         >
-          {isSaving ? "Saving…" : "Save report snapshot"}
+          {isSaving ? <Spinner /> : null}
+          Save report snapshot
         </button>
-        <button
-          type="button"
-          onClick={exportReport}
-          disabled={isExporting}
-          className="rounded-full border border-secondary px-5 py-2.5 font-semibold text-secondary disabled:opacity-60"
-        >
-          {isExporting ? "Exporting…" : "Export CSV report"}
-        </button>
+        {report?.shipment_analysis.shipment_count ? (
+          <button
+            type="button"
+            onClick={exportReport}
+            disabled={isExporting}
+            className="inline-flex items-center gap-2 rounded-lg border border-secondary px-3.5 py-2 text-sm font-semibold text-secondary disabled:opacity-60"
+          >
+            {isExporting ? <Spinner /> : null}
+            Export CSV report
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={() => window.print()}
-          className="rounded-full border border-border px-5 py-2.5 font-semibold text-primary"
+          className="rounded-lg border border-border px-3.5 py-2 text-sm font-semibold text-primary"
         >
           Print report
         </button>
@@ -354,7 +360,7 @@ export default function ReportPage() {
           </article>
         </div>
       ) : isLoading ? (
-        <p className="mt-6 text-sm text-muted-foreground">Loading report…</p>
+        <LoadingState label="Loading report" />
       ) : null}
     </section>
   );

--- a/nzeroesg-client/app/dashboard/scenarios/page.tsx
+++ b/nzeroesg-client/app/dashboard/scenarios/page.tsx
@@ -1,5 +1,43 @@
-import { WorkspaceSectionPage } from "@/app/dashboard/WorkspaceSectionPage";
+import Link from "next/link";
+import { Route } from "lucide-react";
 
 export default function ScenariosPage() {
-  return <WorkspaceSectionPage section="scenarios" />;
+  return (
+    <section className="px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
+      <header>
+        <h1 className="text-3xl font-bold tracking-tight text-primary sm:text-4xl">
+          Scenarios
+        </h1>
+        <p className="mt-2 max-w-2xl leading-7 text-muted-foreground">
+          Compare sourcing and freight alternatives without losing the evidence
+          behind the baseline.
+        </p>
+      </header>
+
+      <article className="mt-7 flex min-h-72 items-center justify-center rounded-xl border border-dashed border-border bg-card p-7 text-center">
+        <div className="max-w-md">
+          <span className="mx-auto flex h-10 w-10 items-center justify-center rounded-lg bg-secondary/10 text-secondary">
+            <Route aria-hidden="true" className="h-5 w-5" />
+          </span>
+          <p className="mt-4 text-xs font-semibold uppercase tracking-[0.14em] text-accent">
+            Coming soon
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-primary">
+            Guided scenario modelling
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            The next iteration will turn agent-proposed alternatives into saved,
+            comparable simulations. Freight comparisons remain available through
+            Ask CarbonSage in the meantime.
+          </p>
+          <Link
+            href="/dashboard/agent"
+            className="mt-5 inline-flex rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent"
+          >
+            Ask CarbonSage
+          </Link>
+        </div>
+      </article>
+    </section>
+  );
 }

--- a/nzeroesg-client/app/globals.css
+++ b/nzeroesg-client/app/globals.css
@@ -5,15 +5,17 @@
 }
 
 :root {
-  --background: #f7f7f5;
-  --foreground: #191b19;
-  --secondary-bg: #f0f1ee;
+  --background: #ffffff;
+  --foreground: #181a18;
+  --secondary-bg: #f4f5f2;
   --secondary-fg: #414641;
   --card: #ffffff;
   --card-foreground: #202320;
-  --muted: #f0f1ee;
-  --muted-foreground: #656b66;
-  --border: #d9ddd8;
+  --muted: #f4f5f2;
+  --muted-foreground: #666c67;
+  --border: #e0e3de;
+  --sidebar: #f4f5f2;
+  --sidebar-border: #dfe2dd;
   --primary: #1c201d;
   --secondary: #245f3e;
   --tertiary: #8a711f;
@@ -30,6 +32,8 @@
   --muted: #202421;
   --muted-foreground: #a9b0aa;
   --border: #343a35;
+  --sidebar: #151815;
+  --sidebar-border: #2d322e;
   --primary: #f1f3ef;
   --secondary: #4f9669;
   --tertiary: #c7ad58;
@@ -44,6 +48,8 @@
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-border: var(--border);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-border: var(--sidebar-border);
   --color-primary: var(--primary);
   --color-secondary-bg: var(--secondary-bg);
   --color-secondary-fg: var(--secondary-fg);

--- a/nzeroesg-client/app/login/page.tsx
+++ b/nzeroesg-client/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 
 import { getBackendUrl } from "@/app/api/urls";
+import { Spinner } from "@/app/components/Spinner";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -72,9 +73,10 @@ export default function LoginPage() {
             type="button"
             onClick={enterDemoWorkspace}
             disabled={isEntering}
-            className="rounded-full bg-secondary px-6 py-3 font-semibold text-white transition hover:bg-accent disabled:cursor-wait disabled:opacity-60"
+            className="inline-flex items-center gap-2 rounded-lg bg-secondary px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-accent disabled:cursor-wait disabled:opacity-60"
           >
-            {isEntering ? "Creating workspace…" : "Enter demo workspace"}
+            {isEntering ? <Spinner /> : null}
+            Enter demo workspace
           </button>
           <Link
             href="/"

--- a/nzeroesg-client/e2e/demo.spec.ts
+++ b/nzeroesg-client/e2e/demo.spec.ts
@@ -8,6 +8,8 @@ const shipmentCsv = [
 
 const supplierEvidence =
   "Supplier ABC holds ISO 14001 certification and operates rail routes in Canada.";
+const emptySupplierCsv =
+  "supplier_id,name,region,certifications,transport_modes,documents\n";
 
 // Render, Neon, and the configured embedding provider can need a few seconds
 // to wake up in the production smoke test. Keep action-result assertions
@@ -72,9 +74,10 @@ test("completes the five-minute demo workflow and exports a report", async ({
     { timeout: backendActionTimeout },
   );
 
-  await page.getByRole("button", { name: "Rename shipments.csv" }).click();
+  await page.getByRole("button", { name: "Actions for shipments.csv" }).click();
+  await page.getByRole("button", { name: "Rename", exact: true }).click();
   await page.getByLabel("Artifact title").fill("Q3 freight baseline");
-  await page.getByRole("button", { name: "Save name" }).click();
+  await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(
     page.getByRole("heading", { name: "Q3 freight baseline" }),
   ).toBeVisible();
@@ -115,17 +118,10 @@ test("completes the five-minute demo workflow and exports a report", async ({
   }
 
   await openWorkspacePage(page, "Scenarios", "scenarios");
-  await page.getByRole("button", { name: "Run scenario" }).click();
-  await expect(page.getByText("Current baseline")).toBeVisible({
-    timeout: backendActionTimeout,
-  });
   await expect(
-    page.getByRole("heading", { name: "Compare an alternative" }),
+    page.getByRole("heading", { name: "Guided scenario modelling" }),
   ).toBeVisible();
-  await expect(page.getByText("Methodology", { exact: true })).toBeVisible();
-  await expect(
-    page.getByRole("table", { name: "Scenario result by shipment" }),
-  ).toBeVisible();
+  await expect(page.getByText("Coming soon", { exact: true })).toBeVisible();
 
   await openWorkspacePage(page, "Report", "report");
   await expect(page.getByText("Current baseline")).toBeVisible({
@@ -151,19 +147,32 @@ test("completes the five-minute demo workflow and exports a report", async ({
   await expect(
     page.getByText("Report snapshot", { exact: true }),
   ).toBeVisible();
-  await page.getByRole("button", { name: /Demo Workspace/ }).click();
-  await page.getByRole("button", { name: "Sign out" }).click();
+  const workspaceMenu = page.getByRole("button", {
+    name: "Open workspace menu",
+  });
+  await workspaceMenu.focus();
+  await page.keyboard.press("Enter");
+  await expect(
+    page.getByRole("link", { name: "How to use CarbonSage" }),
+  ).toBeVisible();
+  const signOut = page.getByRole("button", { name: "Sign out" });
+  await signOut.focus();
+  await page.keyboard.press("Enter");
   await expect(page).toHaveURL(/\/$/);
 });
 
-test("loads the fictional demo dataset from the agent-first empty state", async ({
+test("loads the fictional demo dataset from the agent or integrations", async ({
   page,
 }) => {
   await enterWorkspace(page);
+  await expect(
+    page.getByRole("button", { name: "Load demo data" }),
+  ).toBeVisible();
 
+  await openWorkspacePage(page, "Integrations", "integrations");
   await page.getByRole("button", { name: "Load demo data" }).click();
   await expect(
-    page.getByRole("heading", { name: "What would you like to review?" }),
+    page.getByText("24 suppliers · 6 shipments · 3 cited documents"),
   ).toBeVisible({ timeout: backendActionTimeout });
 
   await openWorkspacePage(page, "Artifacts", "artifacts");
@@ -179,8 +188,19 @@ test("loads the fictional demo dataset from the agent-first empty state", async 
     }),
   ).toBeVisible();
   await expect(
+    page.getByRole("heading", {
+      name: "aurora-packaging-disclosure.txt",
+    }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: /^Actions for / })).toHaveCount(
+    4,
+  );
+  await page
+    .getByRole("button", { name: "Actions for carbonsage-demo-shipments.csv" })
+    .click();
+  await expect(
     page.getByRole("button", { name: "Download source" }),
-  ).toHaveCount(3);
+  ).toBeVisible();
 
   await openWorkspacePage(page, "Shipments", "shipments");
   await expect(page.getByText("6", { exact: true }).first()).toBeVisible();
@@ -190,6 +210,9 @@ test("loads the fictional demo dataset from the agent-first empty state", async 
   ).toBeVisible();
   await expect(
     page.getByText("Northstar Logistics", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Coastal Biofuels", { exact: true }),
   ).toBeVisible();
 });
 
@@ -214,9 +237,15 @@ test("keeps two demo workspaces isolated", async ({ page, browser }) => {
   await openWorkspacePage(secondPage, "Artifacts", "artifacts");
   await expect(
     secondPage.getByText(
-      "No active artifacts yet. Upload shipment data or supplier evidence to create the first workspace artifact.",
+      "No active artifacts yet. Load demo data or upload shipment and supplier sources to begin.",
     ),
   ).toBeVisible();
+  await expect(
+    secondPage.getByRole("button", { name: "Download shipments" }),
+  ).toHaveCount(0);
+  await expect(
+    secondPage.getByRole("button", { name: "Download suppliers" }),
+  ).toHaveCount(0);
   await openWorkspacePage(secondPage, "Suppliers", "evidence");
   await expect(
     secondPage.getByText("No suppliers have been added to this workspace."),
@@ -241,22 +270,40 @@ test("soft-deletes a shipment artifact and removes its active analysis", async (
     },
   );
   await openWorkspacePage(page, "Artifacts", "artifacts");
-  const deleteButton = page.getByRole("button", {
-    name: "Delete shipments.csv",
-  });
+  await page.getByRole("button", { name: "Actions for shipments.csv" }).click();
+  const deleteButton = page.getByRole("button", { name: "Delete" });
   await expect(deleteButton).toBeVisible({ timeout: backendActionTimeout });
   page.once("dialog", (dialog) => dialog.accept());
   await deleteButton.click();
 
   await expect(
     page.getByText(
-      "No active artifacts yet. Upload shipment data or supplier evidence to create the first workspace artifact.",
+      "No active artifacts yet. Load demo data or upload shipment and supplier sources to begin.",
     ),
   ).toBeVisible({ timeout: backendActionTimeout });
   await openWorkspacePage(page, "Scenarios", "scenarios");
   await expect(
-    page.getByRole("button", { name: "Run scenario" }),
-  ).toBeDisabled();
+    page.getByRole("heading", { name: "Guided scenario modelling" }),
+  ).toBeVisible();
+});
+
+test("explains when a supplier CSV is selected as shipment data", async ({
+  page,
+}) => {
+  await enterWorkspace(page);
+  await openWorkspacePage(page, "Shipments", "shipments");
+  await page.getByLabel("Shipment file").setInputFiles({
+    name: "carbonsage-suppliers.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(emptySupplierCsv),
+  });
+  await page.getByRole("button", { name: "Upload and analyze" }).click();
+
+  await expect(page.getByText("We couldn’t import this file")).toBeVisible({
+    timeout: backendActionTimeout,
+  });
+  await expect(page.getByText(/This looks like supplier data/)).toBeVisible();
+  await expect(page.getByText("Emissions by mode")).toHaveCount(0);
 });
 
 test("keeps the deterministic workspace usable when the agent is disabled", async ({
@@ -420,7 +467,7 @@ test("creates, switches, and closes workspace conversations", async ({
   await enterWorkspace(page);
   await openWorkspacePage(page, "Ask CarbonSage", "agent");
   const agent = page.getByRole("region", { name: "CarbonSage" });
-  const conversationSelect = agent.getByLabel("Conversation");
+  const conversationSelect = agent.getByLabel("Conversation", { exact: true });
   await expect(conversationSelect).toHaveValue(
     firstConversation.conversation_id,
   );

--- a/nzeroesg-client/playwright.config.ts
+++ b/nzeroesg-client/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   webServer: useLocalServers
     ? [
         {
-          command: `cd ../nzeroesg-api && APP_ENV=development DATABASE_URL=${databaseUrl} CORS_ORIGINS=${localBaseURL} ${python} -m uvicorn main:app --host 127.0.0.1 --port ${apiPort}`,
+          command: `cd ../nzeroesg-api && APP_ENV=development DATABASE_URL=${databaseUrl} EMBEDDING_PROVIDER= ASSISTANT_ENABLED=false CORS_ORIGINS=${localBaseURL} ${python} -m uvicorn main:app --host 127.0.0.1 --port ${apiPort}`,
           url: `${localApiURL}/health`,
           reuseExistingServer: !process.env.CI,
           timeout: 120_000,

--- a/readme.md
+++ b/readme.md
@@ -39,8 +39,9 @@ The trusted deterministic baseline is live at:
 The intended path is short:
 
 1. Enter an isolated, expiring demo workspace.
-2. Start with the small fictional demo dataset, or upload your own CSV/XLSX
-   shipment data and PDF/TXT supplier evidence.
+2. Start with the guided fictional demo dataset—24 suppliers, six shipments,
+   and three cited disclosures—or upload your own CSV/XLSX shipment data and
+   PDF/TXT supplier evidence.
 3. Ask CarbonSage to review emissions, data quality, supplier claims, or an
    alternative freight decision.
 4. Inspect returned metrics, charts, exact table values, citations, and tool
@@ -68,8 +69,10 @@ available independently.
 - Text and text-based PDF evidence ingestion with structured supplier records,
   recoverable page/chunk citations, and PostgreSQL full-text retrieval.
 - An explicit first-run choice between a checked-in fictional demo dataset and
-  user uploads. Demo sources, retained uploads, normalized shipments, and the
-  supplier catalog are downloadable from the workspace.
+  user uploads. The seed includes 24 supplier profiles, six mixed-mode
+  shipments, and three cited disclosures. Demo sources, retained uploads,
+  normalized shipments, and the supplier catalog are downloadable from the
+  workspace.
 - Explicit lexical, pgvector semantic, and deterministic hybrid retrieval
   modes with workspace filtering, versioned embedding metadata, and a safe
   lexical fallback when no embedding provider is configured.


### PR DESCRIPTION
## What changed

- Reworked the workspace shell into compact Workspace and Simulations navigation groups with an agent-first order, restrained Dub-inspired neutral surfaces, and a standalone DW profile menu.
- Added a shared loading spinner across session, data, upload, search, report, conversation, and agent-action states.
- Added the How to workspace guide and changed Scenarios to a focused coming-soon page.
- Rebuilt Artifacts as responsive expandable rows with source download, rename, and delete actions; empty normalized exports are now hidden.
- Expanded the fictional seed to 24 suppliers, six shipments, and three cited disclosures, and exposed demo loading from Integrations.
- Added a clear corrective message when a supplier CSV is selected for shipment import, without rendering empty analytics.
- Updated roadmap, architecture notes, README, and browser coverage.

## Why

The prior workspace gave operational pages too much visual weight, used oversized controls, and left several ambiguous loading and empty-data states. This change keeps CarbonSage's agent and evidence-grounded decision flow prominent while making the surrounding control plane easier to understand and review.

## Validation

- Backend: Ruff format/check; 101 tests passed, 4 skipped.
- Frontend: Prettier, ESLint, TypeScript, and production Next.js build passed.
- Browser: 10 Playwright workflows passed, including desktop/mobile, demo seeding, artifact actions, empty exports, invalid supplier-file guidance, conversations, and structured responses.
- Repository: secret scan and git diff validation passed.
