### PR TITLE
Cache workspace data and add simulation controls

### DIFF
--- a/docs/app.architecture.md
+++ b/docs/app.architecture.md
@@ -96,12 +96,16 @@ the agent. Its bounded responsibilities are:
 - create and revoke embed clients with exact allowed origins;
 - inspect quotas, evidence completeness, and concise tool activity.
 
-The persistent shell owns session resolution, workspace navigation, and the
-agent launcher. Each route owns only its section's data requests and actions,
-so direct navigation does not depend on client-side state from a previous
-screen. The dedicated agent route keeps the shared structured-response
-renderer open as a full testing surface; the compact launcher makes the same
-agent available while working elsewhere in the control plane.
+The persistent shell owns session resolution, workspace navigation, one agent
+instance that switches between panel and launcher presentation, and the
+lifecycle of a workspace-scoped Zustand cache. Routes read
+shipments, suppliers, artifacts, demo status, and report previews from that
+cache; request deduplication and mutation-driven invalidation prevent route
+changes from repeating API work. The cache is reset when the workspace changes
+or the user signs out, while direct navigation can always rebuild it from the
+server. The dedicated agent route presents the shared structured-response
+renderer as a full testing surface; the same mounted instance becomes a compact
+launcher while working elsewhere in the control plane.
 
 It is not an organization-admin, billing, SSO, or enterprise-RBAC console.
 

--- a/docs/demo-roadmap.md
+++ b/docs/demo-roadmap.md
@@ -926,6 +926,43 @@ Exit gate:
 > inspect or manage artifacts, and reach the core agent without encountering
 > placeholder product language, empty exports, or ambiguous loading states.
 
+### Phase 10.3 — Workspace state lifecycle and simulation controls
+
+Implementation evidence (completed 2026-08-19):
+
+- A workspace-scoped Zustand store owns shipment analysis, suppliers,
+  artifacts, demo status, and report previews for the active browser session.
+  Requests are deduplicated, cached records survive route changes, and changing
+  or leaving the workspace clears the complete client cache.
+- Mutations update or invalidate only their dependent slices. Shipment and
+  evidence imports, artifact deletion, report snapshots, and demo-data changes
+  refresh the affected canonical records while leaving unrelated cached data
+  available. Report previews are cached by comparison mode and an explicit
+  refresh remains available.
+- Integrations renders the demo-data action immediately while status resolution
+  runs in the background. The initial route no longer replaces the action with
+  a long-running status spinner.
+- `DELETE /demo/data` removes only generated artifacts carrying the checked-in
+  demo provenance and demo-created supplier profiles that have no remaining
+  documents. User-uploaded artifacts, normalized records, and supplier evidence
+  remain active. The same Integrations card exposes the confirmed unload action.
+- Shipment import is a compact action beside `Calculate freight`. It opens an
+  accessible modal with drag-and-drop, file browsing, the XLSX template, bounded
+  validation feedback, and a disabled submit state until a file is selected.
+- One persistent agent instance switches between the dedicated panel and
+  compact launcher across every workspace route. Navigation closes an open
+  launcher without discarding conversation state or repeating initialization.
+- The local browser harness uses an isolated Next.js build directory, so the
+  ten Playwright flows can run without reusing or interrupting another local
+  development server. The suite verifies demo load/unload, cached report reuse,
+  shipment import, mutation refreshes, keyboard operation, and responsive layout.
+
+Exit gate:
+
+> Returning to a workspace page reuses current data, simulation records can be
+> removed without touching user uploads, and file import is an intentional
+> modal workflow rather than a permanent page-level form.
+
 ### Phase 11 — Authenticated JavaScript embed
 
 Deliverables:

--- a/nzeroesg-api/api/demo_data.py
+++ b/nzeroesg-api/api/demo_data.py
@@ -8,7 +8,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from api.artifacts import artifact_repository
+from api.artifacts import artifact_repository, schedule_artifact_source_delete
 from api.evidence import _index_document, evidence_repository
 from api.shipments import shipment_repository
 from api.workspaces import require_workspace_principal
@@ -32,6 +32,10 @@ from domain.workspaces.principals import WorkspacePrincipal
 
 demo_data_router = APIRouter(prefix="/demo/data", tags=["workspace"])
 generated_source_retention = SourceRetention(status="ephemeral").to_dict()
+DEMO_ASSET_KEYS = {
+    "shipment-baseline",
+    *(source.key for source in DEMO_EVIDENCE_SOURCES),
+}
 
 
 class DemoDataResponse(BaseModel):
@@ -43,10 +47,11 @@ class DemoDataResponse(BaseModel):
     evidence_document_count: int
 
 
-def _workspace_state(workspace_id: str, *, loaded: bool = False) -> DemoDataResponse:
+def _workspace_state(workspace_id: str) -> DemoDataResponse:
     artifacts = artifact_repository.list_for_workspace(workspace_id)
     shipments = shipment_repository.list_for_workspace(workspace_id)
     suppliers = evidence_repository.list_suppliers(workspace_id)
+    loaded = any(artifact.metadata.get("demo_asset") in DEMO_ASSET_KEYS for artifact in artifacts)
     return DemoDataResponse(
         loaded=loaded,
         has_artifacts=bool(artifacts),
@@ -71,7 +76,7 @@ async def load_demo_data(
     """Load one bounded, fictional dataset into an otherwise empty workspace."""
 
     existing = _workspace_state(principal.workspace_id)
-    if existing.has_artifacts:
+    if existing.has_artifacts or existing.supplier_count:
         return existing
 
     parsed = parse_shipments_csv(
@@ -99,18 +104,11 @@ async def load_demo_data(
         shipment_artifact.artifact_id,
         parsed.rows,
     )
-    artifact_repository.mark_ready(
-        principal.workspace_id,
-        shipment_artifact.artifact_id,
-        {
-            "accepted_rows": len(parsed.rows),
-            "validation_error_count": 0,
-            "warning_count": len(parsed.warnings),
-            "demo_asset": "shipment-baseline",
-            "source_retention": generated_source_retention,
-        },
-    )
-
+    existing_supplier_ids = {
+        supplier.supplier_id
+        for supplier in evidence_repository.list_suppliers(principal.workspace_id)
+    }
+    demo_supplier_ids: list[str] = []
     for demo_supplier in DEMO_SUPPLIERS:
         normalized = normalize_supplier_metadata(
             name=demo_supplier.name,
@@ -118,7 +116,7 @@ async def load_demo_data(
             certifications=demo_supplier.certifications,
             transport_modes=demo_supplier.transport_modes,
         )
-        evidence_repository.upsert_supplier(
+        stored_supplier = evidence_repository.upsert_supplier(
             principal.workspace_id,
             SupplierMetadata(
                 name=normalized[0],
@@ -127,6 +125,22 @@ async def load_demo_data(
                 transport_modes=normalized[3],
             ),
         )
+        if stored_supplier.supplier_id not in existing_supplier_ids:
+            demo_supplier_ids.append(stored_supplier.supplier_id)
+
+    demo_supplier_metadata = sorted(set(demo_supplier_ids))
+    artifact_repository.mark_ready(
+        principal.workspace_id,
+        shipment_artifact.artifact_id,
+        {
+            "accepted_rows": len(parsed.rows),
+            "validation_error_count": 0,
+            "warning_count": len(parsed.warnings),
+            "demo_asset": "shipment-baseline",
+            "demo_supplier_ids": demo_supplier_metadata,
+            "source_retention": generated_source_retention,
+        },
+    )
 
     for source in DEMO_EVIDENCE_SOURCES:
         normalized = normalize_supplier_metadata(
@@ -178,13 +192,70 @@ async def load_demo_data(
                 "chunk_count": len(extraction.document.chunks),
                 "embedding_status": embedding_status,
                 "demo_asset": source.key,
+                "demo_supplier_ids": demo_supplier_metadata,
                 "source_retention": generated_source_retention,
             },
         )
 
-    state = _workspace_state(principal.workspace_id, loaded=True)
+    state = _workspace_state(principal.workspace_id)
     assert all(
         artifact.status is ArtifactStatus.READY
         for artifact in artifact_repository.list_for_workspace(principal.workspace_id)
     )
     return state
+
+
+@demo_data_router.delete("", response_model=DemoDataResponse)
+async def unload_demo_data(
+    principal: Annotated[WorkspacePrincipal, Depends(require_workspace_principal)],
+) -> DemoDataResponse:
+    """Remove generated demo records while preserving user-provided workspace data."""
+
+    artifacts = artifact_repository.list_for_workspace(principal.workspace_id)
+    demo_artifacts = tuple(
+        artifact for artifact in artifacts if artifact.metadata.get("demo_asset") in DEMO_ASSET_KEYS
+    )
+    supplier_ids: set[str] = set()
+    for artifact in demo_artifacts:
+        artifact_supplier_ids = artifact.metadata.get("demo_supplier_ids")
+        if isinstance(artifact_supplier_ids, list):
+            supplier_ids.update(
+                supplier_id for supplier_id in artifact_supplier_ids if isinstance(supplier_id, str)
+            )
+
+    for artifact in demo_artifacts:
+        await schedule_artifact_source_delete(
+            principal.workspace_id,
+            artifact.artifact_id,
+        )
+        artifact_repository.soft_delete(
+            principal.workspace_id,
+            artifact.artifact_id,
+        )
+        if artifact.kind is ArtifactKind.SHIPMENT_DATASET:
+            shipment_repository.delete_for_artifact(
+                principal.workspace_id,
+                artifact.artifact_id,
+            )
+        elif artifact.kind is ArtifactKind.EVIDENCE_DOCUMENT:
+            evidence_repository.delete_for_artifact(
+                principal.workspace_id,
+                artifact.artifact_id,
+            )
+
+    # Demo artifacts created before supplier provenance was recorded can still be
+    # cleaned up by matching the checked-in fictional names, but only after their
+    # generated documents are gone and only when no user document remains.
+    if demo_artifacts and not supplier_ids:
+        demo_names = {supplier.name.casefold() for supplier in DEMO_SUPPLIERS}
+        supplier_ids.update(
+            supplier.supplier_id
+            for supplier in evidence_repository.list_suppliers(principal.workspace_id)
+            if supplier.name.casefold() in demo_names
+        )
+
+    evidence_repository.delete_suppliers_without_documents(
+        principal.workspace_id,
+        tuple(sorted(supplier_ids)),
+    )
+    return _workspace_state(principal.workspace_id)

--- a/nzeroesg-api/persistence/evidence.py
+++ b/nzeroesg-api/persistence/evidence.py
@@ -80,6 +80,12 @@ class EvidenceRepository(Protocol):
 
     def delete_for_artifact(self, workspace_id: str, artifact_id: str) -> int: ...
 
+    def delete_suppliers_without_documents(
+        self,
+        workspace_id: str,
+        supplier_ids: tuple[str, ...],
+    ) -> int: ...
+
 
 def _vector_literal(values: tuple[float, ...]) -> str:
     return "[" + ",".join(format(value, ".12g") for value in values) + "]"
@@ -404,6 +410,21 @@ class InMemoryEvidenceRepository:
             )
             current = self._suppliers[supplier_key]
             self._suppliers[supplier_key] = (current[0], current[1], remaining)
+        return len(matching_keys)
+
+    def delete_suppliers_without_documents(
+        self,
+        workspace_id: str,
+        supplier_ids: tuple[str, ...],
+    ) -> int:
+        requested_ids = set(supplier_ids)
+        matching_keys = [
+            key
+            for key, (supplier_id, _supplier, document_count) in self._suppliers.items()
+            if key[0] == workspace_id and supplier_id in requested_ids and document_count == 0
+        ]
+        for key in matching_keys:
+            del self._suppliers[key]
         return len(matching_keys)
 
 
@@ -906,6 +927,33 @@ class PostgresEvidenceRepository:
                 supplier_ids = [row[0] for row in cursor.fetchall()]
             connection.commit()
         return len(supplier_ids)
+
+    def delete_suppliers_without_documents(
+        self,
+        workspace_id: str,
+        supplier_ids: tuple[str, ...],
+    ) -> int:
+        if not supplier_ids:
+            return 0
+        with closing(self._connect()) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM suppliers AS s
+                    WHERE s.workspace_id = %s
+                      AND s.supplier_id = ANY(%s::uuid[])
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM evidence_documents AS d
+                          WHERE d.workspace_id = s.workspace_id
+                            AND d.supplier_id = s.supplier_id
+                      )
+                    """,
+                    (workspace_id, list(supplier_ids)),
+                )
+                deleted = cursor.rowcount
+            connection.commit()
+        return deleted
 
 
 def build_evidence_repository(database_url: str | None) -> EvidenceRepository:

--- a/nzeroesg-api/tests/test_api.py
+++ b/nzeroesg-api/tests/test_api.py
@@ -283,7 +283,7 @@ def test_demo_data_is_explicit_idempotent_and_downloadable():
         "evidence_document_count": 3,
     }
     assert repeated.status_code == 200
-    assert repeated.json()["loaded"] is False
+    assert repeated.json()["loaded"] is True
     assert repeated.json()["artifact_count"] == 4
 
     artifacts = demo_client.get("/artifacts").json()["artifacts"]
@@ -299,6 +299,61 @@ def test_demo_data_is_explicit_idempotent_and_downloadable():
     assert suppliers_export.status_code == 200
     assert b"Boreal Components" in suppliers_export.content
     assert b"Coastal Biofuels" in suppliers_export.content
+
+
+def test_demo_data_can_be_unloaded_without_removing_user_uploads():
+    demo_client = authenticated_client()
+    assert demo_client.post("/demo/data").status_code == 200
+
+    user_shipments = demo_client.post(
+        "/shipments/upload",
+        files={
+            "file": (
+                "user-shipments.csv",
+                (
+                    b"shipment_id,origin,destination,weight_value,weight_unit,"
+                    b"distance_value,distance_unit,transport_method\n"
+                    b"USER-001,Edmonton,Calgary,1000,kg,300,km,truck\n"
+                ),
+                "text/csv",
+            )
+        },
+    )
+    assert user_shipments.status_code == 200
+
+    user_evidence = demo_client.post(
+        "/evidence/upload",
+        data={"supplier_name": "User Supplier", "supplier_region": "Canada"},
+        files={
+            "file": (
+                "user-supplier.txt",
+                b"User Supplier maintains ISO 14001 certification.",
+                "text/plain",
+            )
+        },
+    )
+    assert user_evidence.status_code == 200
+
+    unloaded = demo_client.delete("/demo/data")
+
+    assert unloaded.status_code == 200
+    assert unloaded.json() == {
+        "loaded": False,
+        "has_artifacts": True,
+        "artifact_count": 2,
+        "shipment_count": 1,
+        "supplier_count": 1,
+        "evidence_document_count": 1,
+    }
+    assert {
+        artifact["title"] for artifact in demo_client.get("/artifacts").json()["artifacts"]
+    } == {"user-shipments.csv", "user-supplier.txt"}
+    assert [supplier["name"] for supplier in demo_client.get("/suppliers").json()["suppliers"]] == [
+        "User Supplier"
+    ]
+    shipments = demo_client.get("/shipments").json()
+    assert shipments["accepted_rows"] == 1
+    assert shipments["rows"][0]["shipment_id"] == "USER-001"
 
 
 def test_supplier_can_be_created_before_evidence_is_available():

--- a/nzeroesg-client/.gitignore
+++ b/nzeroesg-client/.gitignore
@@ -16,6 +16,7 @@
 
 # next.js
 /.next/
+/.next-playwright/
 /out/
 
 # production

--- a/nzeroesg-client/app/components/chat_ui/ChatInterface.tsx
+++ b/nzeroesg-client/app/components/chat_ui/ChatInterface.tsx
@@ -20,12 +20,14 @@ import AgentDetailsPanel from "./AgentDetailsPanel";
 import ChatInput from "./ChatInput";
 import { LoadingIndicator } from "./LoadingIndicator";
 import StructuredResponse from "./StructuredResponse";
+import { useWorkspaceDataStore } from "@/app/dashboard/workspace-data-store";
 
 interface ChatInterfaceProps {
   initialOpen?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   onAction?: (actionId: string, artifactId: string | null) => Promise<void>;
   presentation?: "launcher" | "panel";
+  navigationKey?: string;
 }
 
 const statusLabels: Record<AgentAvailability, string> = {
@@ -40,15 +42,6 @@ const suggestedPrompts = [
   "What data-quality issues should I address?",
   "Compare the current freight baseline with rail.",
 ];
-
-type DemoDataStatus = {
-  loaded: boolean;
-  has_artifacts: boolean;
-  artifact_count: number;
-  shipment_count: number;
-  supplier_count: number;
-  evidence_document_count: number;
-};
 
 async function apiDetail(response: Response, fallback: string) {
   const payload = (await response.json().catch(() => null)) as ApiError | null;
@@ -70,6 +63,7 @@ export default function ChatInterface({
   onOpenChange,
   onAction,
   presentation = "launcher",
+  navigationKey,
 }: ChatInterfaceProps) {
   const isPanel = presentation === "panel";
   const [messages, setMessages] = useState<UiMessage[]>([]);
@@ -86,10 +80,11 @@ export default function ChatInterface({
     useState<AgentAvailability>("checking");
   const [conversationReady, setConversationReady] = useState(false);
   const [controlError, setControlError] = useState<string | null>(null);
-  const [demoData, setDemoData] = useState<DemoDataStatus | null>(null);
+  const demoData = useWorkspaceDataStore((state) => state.demoData);
   const [isLoadingDemoData, setIsLoadingDemoData] = useState(false);
   const conversationId = useRef<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const previousNavigationKey = useRef(navigationKey);
 
   const applyConversationDetail = useCallback(
     (detail: ConversationDetailResponse) => {
@@ -391,30 +386,16 @@ export default function ChatInterface({
   }, [loadConversation]);
 
   useEffect(() => {
-    const controller = new AbortController();
-    fetch(`${getBackendUrl()}/demo/data`, {
-      credentials: "include",
-      signal: controller.signal,
-    })
-      .then(async (response) => {
-        if (!response.ok) return null;
-        return (await response.json()) as DemoDataStatus;
-      })
-      .then((payload) => {
-        if (payload) setDemoData(payload);
-      })
-      .catch(() => undefined);
-
-    function dataLoaded(event: Event) {
-      const customEvent = event as CustomEvent<DemoDataStatus>;
-      if (customEvent.detail) setDemoData(customEvent.detail);
+    if (
+      !isPanel &&
+      previousNavigationKey.current !== undefined &&
+      previousNavigationKey.current !== navigationKey
+    ) {
+      setIsOpen(false);
+      onOpenChange?.(false);
     }
-    window.addEventListener("carbonsage:data-loaded", dataLoaded);
-    return () => {
-      controller.abort();
-      window.removeEventListener("carbonsage:data-loaded", dataLoaded);
-    };
-  }, []);
+    previousNavigationKey.current = navigationKey;
+  }, [isPanel, navigationKey, onOpenChange]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -441,10 +422,12 @@ export default function ChatInterface({
         : assistantStatus === "available"
           ? "Ask about this workspace…"
           : "CarbonSage is not available in this environment";
+  const showInterface =
+    isPanel || (previousNavigationKey.current === navigationKey && isOpen);
 
   return (
     <div>
-      {isOpen ? (
+      {showInterface ? (
         <section
           role={isPanel ? "region" : "dialog"}
           aria-modal={isPanel ? undefined : "false"}

--- a/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
+++ b/nzeroesg-client/app/dashboard/ArtifactCatalog.tsx
@@ -11,38 +11,13 @@ import {
 
 import { getBackendUrl } from "@/app/api/urls";
 import { LoadingState, Spinner } from "@/app/components/Spinner";
+import {
+  type Artifact,
+  type ArtifactKind,
+  useWorkspaceDataStore,
+} from "@/app/dashboard/workspace-data-store";
 
-export type ArtifactKind =
-  | "shipment_dataset"
-  | "evidence_document"
-  | "report_snapshot";
-
-type Artifact = {
-  artifact_id: string;
-  workspace_id: string;
-  kind: ArtifactKind;
-  title: string;
-  status: "processing" | "ready" | "failed";
-  source_type:
-    | "local_upload"
-    | "generated"
-    | "google_drive"
-    | "legacy_migration";
-  source_reference: string | null;
-  media_type: string | null;
-  content_sha256: string | null;
-  version: number;
-  metadata: Record<string, unknown>;
-  created_by: string;
-  created_at: string;
-  updated_at: string;
-  deleted_at: string | null;
-};
-
-type WorkspaceDataStatus = {
-  shipment_count: number;
-  supplier_count: number;
-};
+export type { ArtifactKind } from "@/app/dashboard/workspace-data-store";
 
 const kindLabels: Record<ArtifactKind, string> = {
   shipment_dataset: "Shipment dataset",
@@ -58,8 +33,6 @@ const sourceLabels: Record<Artifact["source_type"], string> = {
 };
 
 type ArtifactCatalogProps = {
-  refreshToken: number;
-  onDeleted: (kind: ArtifactKind) => void | Promise<void>;
   focusedArtifactId?: string;
 };
 
@@ -86,16 +59,25 @@ function sourceRetentionFor(artifact: Artifact): SourceRetention | null {
 }
 
 export default function ArtifactCatalog({
-  refreshToken,
-  onDeleted,
   focusedArtifactId,
 }: ArtifactCatalogProps) {
-  const [artifacts, setArtifacts] = useState<Artifact[]>([]);
-  const [dataStatus, setDataStatus] = useState<WorkspaceDataStatus | null>(
-    null,
+  const artifacts = useWorkspaceDataStore((state) => state.artifacts);
+  const artifactsStatus = useWorkspaceDataStore(
+    (state) => state.artifactsStatus,
   );
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const artifactsError = useWorkspaceDataStore((state) => state.artifactsError);
+  const demoData = useWorkspaceDataStore((state) => state.demoData);
+  const ensureArtifacts = useWorkspaceDataStore(
+    (state) => state.ensureArtifacts,
+  );
+  const ensureDemoData = useWorkspaceDataStore((state) => state.ensureDemoData);
+  const renameCachedArtifact = useWorkspaceDataStore(
+    (state) => state.renameArtifact,
+  );
+  const deleteCachedArtifact = useWorkspaceDataStore(
+    (state) => state.deleteArtifact,
+  );
+  const [actionError, setActionError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(
     focusedArtifactId ?? null,
@@ -105,50 +87,12 @@ export default function ArtifactCatalog({
   const [draftTitle, setDraftTitle] = useState("");
   const [busyId, setBusyId] = useState<string | null>(null);
   const [busyExport, setBusyExport] = useState<string | null>(null);
+  const isLoading = artifactsStatus === "loading" && artifacts.length === 0;
+  const error = actionError ?? artifactsError;
 
   useEffect(() => {
-    let isCurrent = true;
-    const controller = new AbortController();
-    Promise.all([
-      fetch(`${getBackendUrl()}/artifacts`, {
-        credentials: "include",
-        signal: controller.signal,
-      }),
-      fetch(`${getBackendUrl()}/demo/data`, {
-        credentials: "include",
-        signal: controller.signal,
-      }),
-    ])
-      .then(async ([artifactResponse, statusResponse]) => {
-        if (!artifactResponse.ok || !statusResponse.ok) {
-          throw new Error("Workspace artifacts could not be loaded.");
-        }
-        return Promise.all([
-          artifactResponse.json() as Promise<{ artifacts: Artifact[] }>,
-          statusResponse.json() as Promise<WorkspaceDataStatus>,
-        ]);
-      })
-      .then(([artifactPayload, statusPayload]) => {
-        if (!isCurrent) return;
-        setArtifacts(artifactPayload.artifacts);
-        setDataStatus(statusPayload);
-      })
-      .catch((requestError) => {
-        if (!isCurrent || controller.signal.aborted) return;
-        setError(
-          requestError instanceof Error
-            ? requestError.message
-            : "Workspace artifacts could not be loaded.",
-        );
-      })
-      .finally(() => {
-        if (isCurrent) setIsLoading(false);
-      });
-    return () => {
-      isCurrent = false;
-      controller.abort();
-    };
-  }, [refreshToken]);
+    void Promise.allSettled([ensureArtifacts(), ensureDemoData()]);
+  }, [ensureArtifacts, ensureDemoData]);
 
   useEffect(() => {
     if (!focusedArtifactId || !artifacts.length) return;
@@ -160,32 +104,17 @@ export default function ArtifactCatalog({
   async function renameArtifact(artifact: Artifact) {
     const title = draftTitle.trim();
     if (!title) {
-      setError("Artifact title cannot be empty.");
+      setActionError("Artifact title cannot be empty.");
       return;
     }
     setBusyId(artifact.artifact_id);
-    setError(null);
+    setActionError(null);
     try {
-      const response = await fetch(
-        `${getBackendUrl()}/artifacts/${artifact.artifact_id}`,
-        {
-          method: "PATCH",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ title }),
-        },
-      );
-      if (!response.ok) throw new Error("Artifact could not be renamed.");
-      const updated = (await response.json()) as Artifact;
-      setArtifacts((current) =>
-        current.map((item) =>
-          item.artifact_id === updated.artifact_id ? updated : item,
-        ),
-      );
+      const updated = await renameCachedArtifact(artifact.artifact_id, title);
       setEditingId(null);
       setStatusMessage(`Renamed artifact to ${updated.title}.`);
     } catch (requestError) {
-      setError(
+      setActionError(
         requestError instanceof Error
           ? requestError.message
           : "Artifact could not be renamed.",
@@ -205,25 +134,12 @@ export default function ArtifactCatalog({
       return;
     }
     setBusyId(artifact.artifact_id);
-    setError(null);
+    setActionError(null);
     try {
-      const response = await fetch(
-        `${getBackendUrl()}/artifacts/${artifact.artifact_id}`,
-        { method: "DELETE", credentials: "include" },
-      );
-      if (!response.ok) throw new Error("Artifact could not be deleted.");
-      setArtifacts((current) =>
-        current.filter((item) => item.artifact_id !== artifact.artifact_id),
-      );
-      if (artifact.kind === "shipment_dataset") {
-        setDataStatus((current) =>
-          current ? { ...current, shipment_count: 0 } : current,
-        );
-      }
+      await deleteCachedArtifact(artifact);
       setStatusMessage(`Deleted ${artifact.title}.`);
-      await onDeleted(artifact.kind);
     } catch (requestError) {
-      setError(
+      setActionError(
         requestError instanceof Error
           ? requestError.message
           : "Artifact could not be deleted.",
@@ -236,7 +152,7 @@ export default function ArtifactCatalog({
   async function downloadArtifact(artifact: Artifact) {
     setMenuId(null);
     setBusyId(artifact.artifact_id);
-    setError(null);
+    setActionError(null);
     try {
       const response = await fetch(
         `${getBackendUrl()}/artifacts/${artifact.artifact_id}/content`,
@@ -259,7 +175,7 @@ export default function ArtifactCatalog({
       URL.revokeObjectURL(objectUrl);
       setStatusMessage(`Downloaded source for ${artifact.title}.`);
     } catch (requestError) {
-      setError(
+      setActionError(
         requestError instanceof Error
           ? requestError.message
           : "The retained source could not be downloaded.",
@@ -275,7 +191,7 @@ export default function ArtifactCatalog({
     label: string,
   ) {
     setBusyExport(path);
-    setError(null);
+    setActionError(null);
     try {
       const response = await fetch(`${getBackendUrl()}${path}`, {
         credentials: "include",
@@ -291,7 +207,7 @@ export default function ArtifactCatalog({
       URL.revokeObjectURL(objectUrl);
       setStatusMessage(`Downloaded ${label.toLowerCase()}.`);
     } catch (requestError) {
-      setError(
+      setActionError(
         requestError instanceof Error
           ? requestError.message
           : `${label} could not be downloaded.`,
@@ -314,7 +230,7 @@ export default function ArtifactCatalog({
         </div>
         {!isLoading ? (
           <div className="flex flex-wrap items-center gap-2">
-            {dataStatus?.shipment_count ? (
+            {demoData?.shipment_count ? (
               <button
                 type="button"
                 onClick={() =>
@@ -331,7 +247,7 @@ export default function ArtifactCatalog({
                 Download shipments
               </button>
             ) : null}
-            {dataStatus?.supplier_count ? (
+            {demoData?.supplier_count ? (
               <button
                 type="button"
                 onClick={() =>
@@ -475,7 +391,7 @@ export default function ArtifactCatalog({
                             setEditingId(artifact.artifact_id);
                             setDraftTitle(artifact.title);
                             setMenuId(null);
-                            setError(null);
+                            setActionError(null);
                           }}
                           className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-primary hover:bg-muted"
                         >

--- a/nzeroesg-client/app/dashboard/WorkspaceSectionPage.tsx
+++ b/nzeroesg-client/app/dashboard/WorkspaceSectionPage.tsx
@@ -1,70 +1,24 @@
 "use client";
 
-import { type ChangeEvent, type FormEvent, useEffect, useState } from "react";
+import {
+  type ChangeEvent,
+  type DragEvent,
+  type FormEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import Link from "next/link";
-import { X } from "lucide-react";
+import { UploadCloud, X } from "lucide-react";
 
 import { getBackendUrl } from "@/app/api/urls";
 import { LoadingState, Spinner } from "@/app/components/Spinner";
-import ArtifactCatalog, {
-  type ArtifactKind,
-} from "@/app/dashboard/ArtifactCatalog";
+import ArtifactCatalog from "@/app/dashboard/ArtifactCatalog";
 import { useWorkspace } from "@/app/dashboard/WorkspaceShell";
-
-type ShipmentRow = {
-  shipment_id: string;
-  origin: string;
-  destination: string;
-  weight_kg: number;
-  distance_km: number;
-  transport_method: string;
-  source_row: number;
-};
-
-type ShipmentAnalysis = {
-  shipment_count: number;
-  total_weight_kg: number;
-  total_emissions_kg: number;
-  total_emissions_tonnes: number;
-  mode_breakdown: Record<
-    string,
-    { shipment_count: number; weight_kg: number; emissions_kg: number }
-  >;
-  hotspots: Array<{
-    shipment_id: string;
-    origin: string;
-    destination: string;
-    transport_method: string;
-    emissions_kg: number;
-  }>;
-  warnings: string[];
-  factor_source: string;
-  factor_version: string;
-  factor_applicability: string;
-  assumptions: string[];
-};
-
-type ShipmentData = {
-  accepted_rows: number;
-  errors: Array<{
-    row_number: number | null;
-    field: string | null;
-    message: string;
-  }>;
-  warnings: string[];
-  rows: ShipmentRow[];
-  analysis: ShipmentAnalysis;
-};
-
-type SupplierCard = {
-  supplier_id: string;
-  name: string;
-  region: string | null;
-  certifications: string[];
-  transport_modes: string[];
-  document_count: number;
-  missing_fields: string[];
-};
+import {
+  type ShipmentData,
+  useWorkspaceDataStore,
+} from "@/app/dashboard/workspace-data-store";
 
 type RetrievalMode = "lexical" | "semantic" | "hybrid";
 
@@ -174,17 +128,41 @@ export function WorkspaceSectionPage({
 }) {
   const { session, refreshSession } = useWorkspace();
   const details = sectionDetails[section];
-  const [shipmentData, setShipmentData] = useState<ShipmentData | null>(null);
-  const [shipmentError, setShipmentError] = useState<string | null>(null);
+  const shipmentData = useWorkspaceDataStore((state) => state.shipments);
+  const shipmentsStatus = useWorkspaceDataStore(
+    (state) => state.shipmentsStatus,
+  );
+  const cachedShipmentError = useWorkspaceDataStore(
+    (state) => state.shipmentsError,
+  );
+  const ensureShipments = useWorkspaceDataStore(
+    (state) => state.ensureShipments,
+  );
+  const uploadWorkspaceShipments = useWorkspaceDataStore(
+    (state) => state.uploadShipments,
+  );
+  const suppliers = useWorkspaceDataStore((state) => state.suppliers);
+  const suppliersStatus = useWorkspaceDataStore(
+    (state) => state.suppliersStatus,
+  );
+  const cachedSuppliersError = useWorkspaceDataStore(
+    (state) => state.suppliersError,
+  );
+  const ensureSuppliers = useWorkspaceDataStore(
+    (state) => state.ensureSuppliers,
+  );
+  const refreshAfterEvidenceMutation = useWorkspaceDataStore(
+    (state) => state.refreshAfterEvidenceMutation,
+  );
+  const [localShipmentError, setShipmentError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
-  const [isLoadingShipments, setIsLoadingShipments] = useState(
-    section === "shipments" || section === "scenarios",
-  );
-  const [suppliers, setSuppliers] = useState<SupplierCard[]>([]);
-  const [isLoadingSuppliers, setIsLoadingSuppliers] = useState(
-    section === "evidence",
-  );
+  const [isShipmentModalOpen, setIsShipmentModalOpen] = useState(false);
+  const [isDraggingShipmentFile, setIsDraggingShipmentFile] = useState(false);
+  const [shipmentImportIssues, setShipmentImportIssues] = useState<
+    ShipmentData["errors"]
+  >([]);
+  const shipmentInputRef = useRef<HTMLInputElement>(null);
   const [evidenceMatches, setEvidenceMatches] = useState<EvidenceMatch[]>([]);
   const [supplierName, setSupplierName] = useState("");
   const [supplierRegion, setSupplierRegion] = useState("");
@@ -202,71 +180,49 @@ export function WorkspaceSectionPage({
   const [scenarioData, setScenarioData] = useState<ScenarioData | null>(null);
   const [scenarioError, setScenarioError] = useState<string | null>(null);
   const [isRunningScenario, setIsRunningScenario] = useState(false);
-  const [artifactRefreshToken, setArtifactRefreshToken] = useState(0);
-  const [artifactStatus, setArtifactStatus] = useState<string | null>(null);
   const [isSupplierModalOpen, setIsSupplierModalOpen] = useState(false);
+  const shipmentError = localShipmentError ?? cachedShipmentError;
+  const visibleEvidenceError = evidenceError ?? cachedSuppliersError;
+  const isLoadingShipments =
+    shipmentsStatus === "loading" && shipmentData === null;
+  const isLoadingSuppliers =
+    suppliersStatus === "loading" && suppliers.length === 0;
 
   useEffect(() => {
     if (section !== "shipments" && section !== "scenarios") return;
-    let isCurrent = true;
-
-    fetch(`${getBackendUrl()}/shipments`, { credentials: "include" })
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error("Shipment data could not be loaded.");
-        }
-        return (await response.json()) as ShipmentData;
-      })
-      .then((shipments) => {
-        if (isCurrent) {
-          setShipmentData(shipments);
-        }
-      })
-      .catch(() => {
-        if (isCurrent) {
-          setShipmentError("Shipment data could not be loaded from the API.");
-        }
-      })
-      .finally(() => {
-        if (isCurrent) setIsLoadingShipments(false);
-      });
-
-    return () => {
-      isCurrent = false;
-    };
-  }, [section, session.workspace_id]);
+    void ensureShipments().catch(() => undefined);
+  }, [ensureShipments, section, session.workspace_id]);
 
   useEffect(() => {
     if (section !== "evidence") return;
-    let isCurrent = true;
-    fetch(`${getBackendUrl()}/suppliers`, { credentials: "include" })
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error("Supplier evidence could not be loaded.");
-        }
-        return (await response.json()) as { suppliers: SupplierCard[] };
-      })
-      .then((payload) => {
-        if (isCurrent) setSuppliers(payload.suppliers);
-      })
-      .catch(() => {
-        if (isCurrent) {
-          setEvidenceError(
-            "Supplier evidence could not be loaded from the API.",
-          );
-        }
-      })
-      .finally(() => {
-        if (isCurrent) setIsLoadingSuppliers(false);
-      });
-    return () => {
-      isCurrent = false;
-    };
-  }, [section, session.workspace_id]);
+    void ensureSuppliers().catch(() => undefined);
+  }, [ensureSuppliers, section, session.workspace_id]);
 
   function selectShipmentFile(event: ChangeEvent<HTMLInputElement>) {
     setSelectedFile(event.target.files?.[0] ?? null);
     setShipmentError(null);
+    setShipmentImportIssues([]);
+  }
+
+  function dropShipmentFile(event: DragEvent<HTMLLabelElement>) {
+    event.preventDefault();
+    setIsDraggingShipmentFile(false);
+    const file = event.dataTransfer.files?.[0] ?? null;
+    if (file) {
+      setSelectedFile(file);
+      setShipmentError(null);
+      setShipmentImportIssues([]);
+    }
+  }
+
+  function closeShipmentImport() {
+    if (isUploading) return;
+    setIsShipmentModalOpen(false);
+    setIsDraggingShipmentFile(false);
+    setSelectedFile(null);
+    setShipmentError(null);
+    setShipmentImportIssues([]);
+    if (shipmentInputRef.current) shipmentInputRef.current.value = "";
   }
 
   async function uploadShipments(event: FormEvent<HTMLFormElement>) {
@@ -279,24 +235,18 @@ export function WorkspaceSectionPage({
     setIsUploading(true);
     setShipmentError(null);
     try {
-      const formData = new FormData();
-      formData.append("file", selectedFile);
-      const response = await fetch(`${getBackendUrl()}/shipments/upload`, {
-        method: "POST",
-        body: formData,
-        credentials: "include",
-      });
-      if (!response.ok) {
-        const detail = (await response.json().catch(() => null)) as {
-          detail?: string;
-        } | null;
-        throw new Error(
-          detail?.detail ?? "Shipment data could not be uploaded.",
+      const payload = await uploadWorkspaceShipments(selectedFile);
+      if (payload.accepted_rows > 0) {
+        setShipmentImportIssues([]);
+        setSelectedFile(null);
+        if (shipmentInputRef.current) shipmentInputRef.current.value = "";
+        setIsShipmentModalOpen(false);
+      } else {
+        setShipmentImportIssues(payload.errors);
+        setShipmentError(
+          "We couldn’t import this file. Review the file issues below.",
         );
       }
-      setShipmentData((await response.json()) as ShipmentData);
-      setArtifactRefreshToken((current) => current + 1);
-      setSelectedFile(null);
       await refreshSession();
     } catch (requestError) {
       setShipmentError(
@@ -361,16 +311,7 @@ export function WorkspaceSectionPage({
         } | null;
         throw new Error(detail?.detail ?? "Evidence could not be uploaded.");
       }
-      const suppliersResponse = await fetch(`${getBackendUrl()}/suppliers`, {
-        credentials: "include",
-      });
-      if (suppliersResponse.ok) {
-        const payload = (await suppliersResponse.json()) as {
-          suppliers: SupplierCard[];
-        };
-        setSuppliers(payload.suppliers);
-      }
-      setArtifactRefreshToken((current) => current + 1);
+      await refreshAfterEvidenceMutation();
       setEvidenceFile(null);
       setSupplierName("");
       setSupplierRegion("");
@@ -459,36 +400,6 @@ export function WorkspaceSectionPage({
     }
   }
 
-  async function handleArtifactDeleted(kind: ArtifactKind) {
-    setArtifactRefreshToken((current) => current + 1);
-    if (kind === "shipment_dataset") {
-      setShipmentData(null);
-      setScenarioData(null);
-      setArtifactStatus(
-        "The shipment dataset and its active analysis were removed.",
-      );
-      return;
-    }
-    if (kind === "evidence_document") {
-      setEvidenceMatches([]);
-      setEvidenceSearchData(null);
-      const response = await fetch(`${getBackendUrl()}/suppliers`, {
-        credentials: "include",
-      });
-      if (response.ok) {
-        const payload = (await response.json()) as {
-          suppliers: SupplierCard[];
-        };
-        setSuppliers(payload.suppliers);
-      }
-      setArtifactStatus(
-        "The evidence artifact was removed from active retrieval.",
-      );
-      return;
-    }
-    setArtifactStatus("The saved report snapshot was removed.");
-  }
-
   const modeBreakdown = shipmentData
     ? Object.entries(shipmentData.analysis.mode_breakdown)
     : [];
@@ -526,12 +437,25 @@ export function WorkspaceSectionPage({
           </button>
         ) : null}
         {section === "shipments" ? (
-          <Link
-            href="/dashboard/agent"
-            className="rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent"
-          >
-            Calculate freight
-          </Link>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setShipmentError(null);
+                setShipmentImportIssues([]);
+                setIsShipmentModalOpen(true);
+              }}
+              className="rounded-lg border border-border bg-card px-3.5 py-2 text-sm font-semibold text-primary transition hover:border-accent"
+            >
+              Import shipments
+            </button>
+            <Link
+              href="/dashboard/agent"
+              className="rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent"
+            >
+              Calculate freight
+            </Link>
+          </div>
         ) : null}
       </header>
 
@@ -618,21 +542,141 @@ export function WorkspaceSectionPage({
       ) : null}
 
       {section === "artifacts" ? (
-        <ArtifactCatalog
-          refreshToken={artifactRefreshToken}
-          onDeleted={handleArtifactDeleted}
-          focusedArtifactId={focusedArtifactId}
-        />
-      ) : null}
-
-      {section === "artifacts" ? (
-        <p className="sr-only" role="status" aria-live="polite">
-          {artifactStatus}
-        </p>
+        <ArtifactCatalog focusedArtifactId={focusedArtifactId} />
       ) : null}
 
       {section === "shipments" ? (
         <section id="shipments" className="space-y-6">
+          {isShipmentModalOpen ? (
+            <>
+              <button
+                type="button"
+                aria-label="Close import shipments dialog"
+                onClick={closeShipmentImport}
+                className="fixed inset-0 z-[60] cursor-default bg-black/35 backdrop-blur-[1px]"
+              />
+              <form
+                onSubmit={uploadShipments}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="import-shipments-title"
+                className="fixed left-1/2 top-1/2 z-[70] w-[min(42rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-card p-5 shadow-2xl sm:p-6"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h2
+                      id="import-shipments-title"
+                      className="text-xl font-semibold text-primary"
+                    >
+                      Import shipments
+                    </h2>
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      Upload a CSV or XLSX workbook. CarbonSage will normalize
+                      common column names and keep any row-level issues visible.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={closeShipmentImport}
+                    disabled={isUploading}
+                    aria-label="Close dialog"
+                    className="rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-primary disabled:opacity-50"
+                  >
+                    <X aria-hidden="true" className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <label
+                  onDragEnter={(event) => {
+                    event.preventDefault();
+                    setIsDraggingShipmentFile(true);
+                  }}
+                  onDragOver={(event) => event.preventDefault()}
+                  onDragLeave={(event) => {
+                    if (
+                      !event.currentTarget.contains(event.relatedTarget as Node)
+                    ) {
+                      setIsDraggingShipmentFile(false);
+                    }
+                  }}
+                  onDrop={dropShipmentFile}
+                  className={`mt-5 flex cursor-pointer flex-col items-center rounded-xl border border-dashed px-5 py-9 text-center transition ${
+                    isDraggingShipmentFile
+                      ? "border-accent bg-accent/10"
+                      : "border-border bg-muted/45 hover:border-accent hover:bg-accent/5"
+                  }`}
+                >
+                  <input
+                    ref={shipmentInputRef}
+                    type="file"
+                    aria-label="Shipment file"
+                    accept=".csv,.xlsx,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                    onChange={selectShipmentFile}
+                    className="sr-only"
+                  />
+                  <span className="flex h-11 w-11 items-center justify-center rounded-xl border border-border bg-card text-secondary">
+                    <UploadCloud aria-hidden="true" className="h-5 w-5" />
+                  </span>
+                  <span className="mt-4 text-sm font-semibold text-primary">
+                    {selectedFile
+                      ? selectedFile.name
+                      : "Drop a shipment file here"}
+                  </span>
+                  <span className="mt-1 text-xs text-muted-foreground">
+                    CSV or XLSX · up to 500 rows · 10 MB
+                  </span>
+                  <span className="mt-4 rounded-lg border border-border bg-card px-3 py-2 text-xs font-semibold text-primary shadow-sm">
+                    Browse files
+                  </span>
+                </label>
+
+                {shipmentError ? (
+                  <p className="mt-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
+                    {shipmentError}
+                  </p>
+                ) : null}
+                {shipmentImportIssues.length ? (
+                  <ul className="mt-3 max-h-28 list-disc space-y-1 overflow-y-auto pl-5 text-xs text-amber-900">
+                    {shipmentImportIssues.slice(0, 8).map((issue, index) => (
+                      <li key={`${issue.row_number}-${issue.field}-${index}`}>
+                        {issue.row_number ? `Row ${issue.row_number}: ` : ""}
+                        {issue.field ? `${issue.field} — ` : ""}
+                        {issue.message}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+                  <a
+                    href={`${getBackendUrl()}/shipments/template`}
+                    className="text-sm font-semibold text-secondary hover:text-accent"
+                  >
+                    Download XLSX template
+                  </a>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={closeShipmentImport}
+                      disabled={isUploading}
+                      className="rounded-lg border border-border px-3.5 py-2 text-sm font-semibold text-primary disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={isUploading || !selectedFile}
+                      className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isUploading ? <Spinner /> : null}
+                      Upload and analyze
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </>
+          ) : null}
+
           <div className="grid gap-4 md:grid-cols-3">
             <article className="rounded-xl border border-border bg-card p-5">
               <p className="text-sm text-muted-foreground">Shipments</p>
@@ -655,52 +699,7 @@ export function WorkspaceSectionPage({
             </article>
           </div>
 
-          <div className="rounded-xl border border-border bg-card p-5 sm:p-6">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-              <div>
-                <h2 className="text-xl font-semibold text-primary">
-                  Import shipments
-                </h2>
-                <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                  Add a CSV or XLSX workbook. Common column names are matched
-                  automatically, and rows needing attention remain visible.
-                </p>
-              </div>
-              <a
-                href={`${getBackendUrl()}/shipments/template`}
-                className="text-sm font-semibold text-secondary hover:text-accent"
-              >
-                Download XLSX template
-              </a>
-            </div>
-            <form
-              onSubmit={uploadShipments}
-              className="mt-5 flex flex-wrap items-end gap-3"
-            >
-              <label className="flex w-full min-w-0 flex-1 flex-col gap-2 text-sm font-semibold text-primary sm:min-w-64">
-                Shipment file
-                <input
-                  type="file"
-                  accept=".csv,.xlsx,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                  onChange={selectShipmentFile}
-                  className="w-full min-w-0 max-w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-normal text-primary file:mr-3 file:rounded file:border-0 file:bg-secondary file:px-3 file:py-2 file:text-white"
-                />
-              </label>
-              <button
-                type="submit"
-                disabled={isUploading}
-                className="inline-flex items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent disabled:cursor-wait disabled:opacity-60"
-              >
-                {isUploading ? <Spinner /> : null}
-                Upload and analyze
-              </button>
-            </form>
-            <p className="mt-3 text-xs text-muted-foreground">
-              Max 500 rows · 10 MB
-            </p>
-          </div>
-
-          {shipmentError ? (
+          {shipmentError && !isShipmentModalOpen ? (
             <p className="mt-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
               {shipmentError}
             </p>
@@ -710,7 +709,7 @@ export function WorkspaceSectionPage({
             <LoadingState label="Loading shipment data" />
           ) : shipmentData ? (
             <>
-              {shipmentData.errors.length > 0 ? (
+              {shipmentData.errors.length > 0 && !isShipmentModalOpen ? (
                 <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
                   <p className="font-semibold">
                     {shipmentData.accepted_rows === 0
@@ -1005,9 +1004,9 @@ export function WorkspaceSectionPage({
             </>
           ) : null}
 
-          {evidenceError ? (
+          {visibleEvidenceError ? (
             <p className="order-1 mt-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
-              {evidenceError}
+              {visibleEvidenceError}
             </p>
           ) : null}
 

--- a/nzeroesg-client/app/dashboard/WorkspaceShell.tsx
+++ b/nzeroesg-client/app/dashboard/WorkspaceShell.tsx
@@ -32,6 +32,7 @@ import { getBackendUrl } from "@/app/api/urls";
 import { LoadingState } from "@/app/components/Spinner";
 import ChatInterface from "@/app/components/chat_ui/ChatInterface";
 import { runWorkspaceAgentAction } from "@/app/dashboard/agent-actions";
+import { useWorkspaceDataStore } from "@/app/dashboard/workspace-data-store";
 import { useTheme } from "@/app/utils/contexts/ThemeContext";
 
 export type Quota = { used: number; limit: number };
@@ -131,7 +132,9 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
     if (!response.ok) {
       throw new Error("The workspace could not be loaded.");
     }
-    setSession((await response.json()) as WorkspaceSession);
+    const workspace = (await response.json()) as WorkspaceSession;
+    useWorkspaceDataStore.getState().setWorkspace(workspace.workspace_id);
+    setSession(workspace);
   }, [router]);
 
   useEffect(() => {
@@ -162,7 +165,15 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
         return (await response.json()) as WorkspaceSession;
       })
       .then((workspace) => {
-        if (workspace && isCurrent) setSession(workspace);
+        if (workspace && isCurrent) {
+          const workspaceData = useWorkspaceDataStore.getState();
+          workspaceData.setWorkspace(workspace.workspace_id);
+          setSession(workspace);
+          void useWorkspaceDataStore
+            .getState()
+            .ensureDemoData()
+            .catch(() => undefined);
+        }
       })
       .catch((requestError) => {
         if (isCurrent) {
@@ -185,6 +196,7 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
         credentials: "include",
       });
     } finally {
+      useWorkspaceDataStore.getState().resetWorkspace();
       router.replace("/");
       router.refresh();
     }
@@ -349,10 +361,22 @@ export default function WorkspaceShell({ children }: { children: ReactNode }) {
 
         <main className="min-w-0 flex-1 bg-background text-primary">
           {children}
+          <div
+            className={
+              pathname === "/dashboard/agent"
+                ? "px-4 pb-7 sm:px-6 lg:px-10 lg:pb-9"
+                : ""
+            }
+          >
+            <ChatInterface
+              navigationKey={pathname}
+              onAction={runWorkspaceAgentAction}
+              presentation={
+                pathname === "/dashboard/agent" ? "panel" : "launcher"
+              }
+            />
+          </div>
         </main>
-        {pathname === "/dashboard/agent" ? null : (
-          <ChatInterface key={pathname} onAction={runWorkspaceAgentAction} />
-        )}
       </div>
     </WorkspaceContext.Provider>
   );

--- a/nzeroesg-client/app/dashboard/agent-actions.ts
+++ b/nzeroesg-client/app/dashboard/agent-actions.ts
@@ -1,4 +1,5 @@
 import { getBackendUrl } from "@/app/api/urls";
+import { useWorkspaceDataStore } from "@/app/dashboard/workspace-data-store";
 
 export async function runWorkspaceAgentAction(
   actionId: string,
@@ -6,18 +7,7 @@ export async function runWorkspaceAgentAction(
 ) {
   void artifactId;
   if (actionId === "workspace.load_demo_data") {
-    const response = await fetch(`${getBackendUrl()}/demo/data`, {
-      method: "POST",
-      credentials: "include",
-    });
-    if (!response.ok) {
-      const payload = (await response.json().catch(() => null)) as {
-        detail?: string;
-      } | null;
-      throw new Error(payload?.detail ?? "Demo data could not be loaded.");
-    }
-    const detail = await response.json();
-    window.dispatchEvent(new CustomEvent("carbonsage:data-loaded", { detail }));
+    await useWorkspaceDataStore.getState().loadDemoData();
     return;
   }
 

--- a/nzeroesg-client/app/dashboard/agent/page.tsx
+++ b/nzeroesg-client/app/dashboard/agent/page.tsx
@@ -1,11 +1,6 @@
-"use client";
-
-import ChatInterface from "@/app/components/chat_ui/ChatInterface";
-import { runWorkspaceAgentAction } from "@/app/dashboard/agent-actions";
-
 export default function AgentPage() {
   return (
-    <section className="px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
+    <section className="px-4 pt-7 sm:px-6 lg:px-10 lg:pt-9">
       <header className="mb-6">
         <h1 className="text-3xl font-bold tracking-tight text-primary sm:text-4xl">
           Ask CarbonSage
@@ -15,8 +10,6 @@ export default function AgentPage() {
           sources and calculations behind each answer.
         </p>
       </header>
-
-      <ChatInterface presentation="panel" onAction={runWorkspaceAgentAction} />
     </section>
   );
 }

--- a/nzeroesg-client/app/dashboard/integrations/page.tsx
+++ b/nzeroesg-client/app/dashboard/integrations/page.tsx
@@ -1,78 +1,76 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { Cloud, Database, FileCheck2, LockKeyhole } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Cloud, Database, FileCheck2, LockKeyhole, Trash2 } from "lucide-react";
 
-import { getBackendUrl } from "@/app/api/urls";
 import { Spinner } from "@/app/components/Spinner";
-import { runWorkspaceAgentAction } from "@/app/dashboard/agent-actions";
-
-type DemoDataStatus = {
-  has_artifacts: boolean;
-  shipment_count: number;
-  supplier_count: number;
-  evidence_document_count: number;
-};
+import { useWorkspaceDataStore } from "@/app/dashboard/workspace-data-store";
 
 export default function IntegrationsPage() {
-  const [demoData, setDemoData] = useState<DemoDataStatus | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingDemoData, setIsLoadingDemoData] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const refreshDemoData = useCallback(async () => {
-    const response = await fetch(`${getBackendUrl()}/demo/data`, {
-      credentials: "include",
-    });
-    if (!response.ok) throw new Error("Workspace data status is unavailable.");
-    setDemoData((await response.json()) as DemoDataStatus);
-  }, []);
+  const demoData = useWorkspaceDataStore((state) => state.demoData);
+  const demoError = useWorkspaceDataStore((state) => state.demoError);
+  const ensureDemoData = useWorkspaceDataStore((state) => state.ensureDemoData);
+  const loadWorkspaceDemoData = useWorkspaceDataStore(
+    (state) => state.loadDemoData,
+  );
+  const unloadWorkspaceDemoData = useWorkspaceDataStore(
+    (state) => state.unloadDemoData,
+  );
+  const [pendingAction, setPendingAction] = useState<"load" | "unload" | null>(
+    null,
+  );
+  const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
-    let isCurrent = true;
-    fetch(`${getBackendUrl()}/demo/data`, { credentials: "include" })
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error("Workspace data status is unavailable.");
-        }
-        return (await response.json()) as DemoDataStatus;
-      })
-      .then((payload) => {
-        if (isCurrent) setDemoData(payload);
-      })
-      .catch((requestError) => {
-        if (isCurrent) {
-          setError(
-            requestError instanceof Error
-              ? requestError.message
-              : "Workspace data status is unavailable.",
-          );
-        }
-      })
-      .finally(() => {
-        if (isCurrent) setIsLoading(false);
-      });
-    return () => {
-      isCurrent = false;
-    };
-  }, []);
+    void ensureDemoData().catch(() => undefined);
+  }, [ensureDemoData]);
 
   async function loadDemoData() {
-    setIsLoadingDemoData(true);
-    setError(null);
+    setPendingAction("load");
+    setActionError(null);
     try {
-      await runWorkspaceAgentAction("workspace.load_demo_data", null);
-      await refreshDemoData();
+      await loadWorkspaceDemoData();
     } catch (requestError) {
-      setError(
+      setActionError(
         requestError instanceof Error
           ? requestError.message
           : "Demo simulation data could not be loaded.",
       );
     } finally {
-      setIsLoadingDemoData(false);
+      setPendingAction(null);
     }
   }
+
+  async function unloadDemoData() {
+    if (
+      !window.confirm(
+        "Unload the fictional simulation dataset? User-uploaded files and records will remain in this workspace.",
+      )
+    ) {
+      return;
+    }
+    setPendingAction("unload");
+    setActionError(null);
+    try {
+      await unloadWorkspaceDemoData();
+    } catch (requestError) {
+      setActionError(
+        requestError instanceof Error
+          ? requestError.message
+          : "Demo simulation data could not be removed.",
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  const hasWorkspaceData = Boolean(
+    demoData &&
+      (demoData.has_artifacts ||
+        demoData.shipment_count ||
+        demoData.supplier_count),
+  );
+  const error = actionError ?? demoError;
 
   return (
     <section className="px-4 py-7 sm:px-6 lg:px-10 lg:py-9">
@@ -106,10 +104,10 @@ export default function IntegrationsPage() {
                 </h2>
                 <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
                   Load a fictional workspace with 24 supplier profiles, cited
-                  disclosures, and a mixed-mode shipment baseline. It can be
-                  removed at any time from Artifacts.
+                  disclosures, and a mixed-mode shipment baseline. Unloading it
+                  removes only seeded simulation records—not your uploads.
                 </p>
-                {demoData?.has_artifacts ? (
+                {demoData?.loaded ? (
                   <p className="mt-3 inline-flex items-center gap-2 text-xs font-medium text-secondary">
                     <FileCheck2 aria-hidden="true" className="h-4 w-4" />
                     {demoData.supplier_count} suppliers ·{" "}
@@ -119,20 +117,37 @@ export default function IntegrationsPage() {
                 ) : null}
               </div>
             </div>
-            {isLoading ? (
-              <Spinner label="Checking demo data" className="h-5 w-5" />
-            ) : demoData?.has_artifacts ? (
-              <span className="shrink-0 rounded-md bg-secondary/10 px-2.5 py-1.5 text-xs font-semibold text-secondary">
-                Loaded
+            {demoData?.loaded ? (
+              <div className="flex shrink-0 flex-wrap items-center gap-2">
+                <span className="rounded-md bg-secondary/10 px-2.5 py-1.5 text-xs font-semibold text-secondary">
+                  Loaded
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void unloadDemoData()}
+                  disabled={pendingAction !== null}
+                  className="inline-flex items-center gap-2 rounded-lg border border-border px-3.5 py-2 text-sm font-semibold text-primary transition hover:border-red-300 hover:text-red-700 disabled:opacity-60"
+                >
+                  {pendingAction === "unload" ? (
+                    <Spinner />
+                  ) : (
+                    <Trash2 aria-hidden="true" className="h-4 w-4" />
+                  )}
+                  Unload demo data
+                </button>
+              </div>
+            ) : hasWorkspaceData ? (
+              <span className="shrink-0 rounded-md border border-border bg-muted px-2.5 py-1.5 text-xs font-semibold text-muted-foreground">
+                Workspace data present
               </span>
             ) : (
               <button
                 type="button"
                 onClick={() => void loadDemoData()}
-                disabled={isLoadingDemoData}
+                disabled={pendingAction !== null}
                 className="inline-flex shrink-0 items-center gap-2 rounded-lg bg-secondary px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-accent disabled:opacity-60"
               >
-                {isLoadingDemoData ? <Spinner /> : null}
+                {pendingAction === "load" ? <Spinner /> : null}
                 Load demo data
               </button>
             )}

--- a/nzeroesg-client/app/dashboard/report/page.tsx
+++ b/nzeroesg-client/app/dashboard/report/page.tsx
@@ -4,116 +4,53 @@ import { useEffect, useState } from "react";
 
 import { getBackendUrl } from "@/app/api/urls";
 import { LoadingState, Spinner } from "@/app/components/Spinner";
-
-type ModeBreakdown = {
-  shipment_count: number;
-  weight_kg: number;
-  emissions_kg: number;
-};
-
-type ReportData = {
-  generated_at: number;
-  shipment_analysis: {
-    shipment_count: number;
-    total_weight_kg: number;
-    total_emissions_kg: number;
-    total_emissions_tonnes: number;
-    mode_breakdown: Record<string, ModeBreakdown>;
-  };
-  scenario: {
-    baseline_mode: string;
-    alternative_mode: string;
-    shipment_count: number;
-    baseline_total_kg: number;
-    alternative_total_kg: number;
-    delta_kg: number;
-    delta_percent: number | null;
-  } | null;
-  suppliers: Array<{
-    supplier_id: string;
-    name: string;
-    region: string | null;
-    document_count: number;
-  }>;
-  methodology: {
-    factor_source: string;
-    factor_version: string;
-    factor_applicability: string;
-    assumptions: string[];
-    warnings: string[];
-  };
-};
+import { useWorkspaceDataStore } from "@/app/dashboard/workspace-data-store";
 
 const alternatives = ["plane", "truck", "train", "ship"] as const;
 
 export default function ReportPage() {
   const [alternativeMode, setAlternativeMode] = useState("train");
-  const [report, setReport] = useState<ReportData | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const report = useWorkspaceDataStore(
+    (state) => state.reports[alternativeMode] ?? null,
+  );
+  const reportStatus = useWorkspaceDataStore(
+    (state) => state.reportStatuses[alternativeMode] ?? "idle",
+  );
+  const reportError = useWorkspaceDataStore(
+    (state) => state.reportErrors[alternativeMode] ?? null,
+  );
+  const ensureReport = useWorkspaceDataStore((state) => state.ensureReport);
+  const refreshAfterReportSnapshot = useWorkspaceDataStore(
+    (state) => state.refreshAfterReportSnapshot,
+  );
+  const [actionError, setActionError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-
-  async function requestReport(mode: string) {
-    const query = mode ? `?alternative_mode=${encodeURIComponent(mode)}` : "";
-    const response = await fetch(`${getBackendUrl()}/reports/preview${query}`, {
-      credentials: "include",
-    });
-    if (!response.ok) {
-      const payload = (await response.json().catch(() => null)) as {
-        detail?: string;
-      } | null;
-      throw new Error(
-        payload?.detail ?? "The report preview could not be loaded.",
-      );
-    }
-    return (await response.json()) as ReportData;
-  }
+  const isLoading = reportStatus === "loading";
+  const error = actionError ?? reportError;
 
   useEffect(() => {
-    let isCurrent = true;
-    requestReport("train")
-      .then((payload) => {
-        if (isCurrent) setReport(payload);
-      })
-      .catch((requestError) => {
-        if (isCurrent) {
-          setError(
-            requestError instanceof Error
-              ? requestError.message
-              : "The report preview could not be loaded.",
-          );
-        }
-      })
-      .finally(() => {
-        if (isCurrent) setIsLoading(false);
-      });
-    return () => {
-      isCurrent = false;
-    };
-  }, []);
+    void ensureReport(alternativeMode).catch(() => undefined);
+  }, [alternativeMode, ensureReport]);
 
   async function refreshReport() {
-    setIsLoading(true);
-    setError(null);
+    setActionError(null);
     setStatusMessage(null);
     try {
-      setReport(await requestReport(alternativeMode));
+      await ensureReport(alternativeMode, true);
     } catch (requestError) {
-      setError(
+      setActionError(
         requestError instanceof Error
           ? requestError.message
           : "The report preview could not be loaded.",
       );
-    } finally {
-      setIsLoading(false);
     }
   }
 
   async function exportReport() {
     setIsExporting(true);
-    setError(null);
+    setActionError(null);
     try {
       const response = await fetch(
         `${getBackendUrl()}/reports/export.csv?alternative_mode=${encodeURIComponent(alternativeMode)}`,
@@ -130,7 +67,7 @@ export default function ReportPage() {
       link.remove();
       URL.revokeObjectURL(objectUrl);
     } catch (requestError) {
-      setError(
+      setActionError(
         requestError instanceof Error
           ? requestError.message
           : "Report export could not be completed.",
@@ -142,7 +79,7 @@ export default function ReportPage() {
 
   async function saveSnapshot() {
     setIsSaving(true);
-    setError(null);
+    setActionError(null);
     setStatusMessage(null);
     try {
       const response = await fetch(`${getBackendUrl()}/reports/snapshots`, {
@@ -162,9 +99,10 @@ export default function ReportPage() {
       const payload = (await response.json()) as {
         artifact: { title: string };
       };
+      await refreshAfterReportSnapshot();
       setStatusMessage(`Saved ${payload.artifact.title}.`);
     } catch (requestError) {
-      setError(
+      setActionError(
         requestError instanceof Error
           ? requestError.message
           : "Report snapshot could not be saved.",
@@ -194,7 +132,10 @@ export default function ReportPage() {
           Report alternative
           <select
             value={alternativeMode}
-            onChange={(event) => setAlternativeMode(event.target.value)}
+            onChange={(event) => {
+              setActionError(null);
+              setAlternativeMode(event.target.value);
+            }}
             className="rounded-lg border border-border bg-background px-3 py-2 font-normal capitalize"
           >
             {alternatives.map((mode) => (

--- a/nzeroesg-client/app/dashboard/workspace-data-store.ts
+++ b/nzeroesg-client/app/dashboard/workspace-data-store.ts
@@ -1,0 +1,727 @@
+"use client";
+
+import { create } from "zustand";
+
+import { getBackendUrl } from "@/app/api/urls";
+
+export type LoadStatus = "idle" | "loading" | "ready" | "error";
+
+export type DemoDataStatus = {
+  loaded: boolean;
+  has_artifacts: boolean;
+  artifact_count: number;
+  shipment_count: number;
+  supplier_count: number;
+  evidence_document_count: number;
+};
+
+export type ShipmentRow = {
+  shipment_id: string;
+  origin: string;
+  destination: string;
+  weight_kg: number;
+  distance_km: number;
+  transport_method: string;
+  source_row: number;
+};
+
+export type ShipmentAnalysis = {
+  shipment_count: number;
+  total_weight_kg: number;
+  total_emissions_kg: number;
+  total_emissions_tonnes: number;
+  mode_breakdown: Record<
+    string,
+    { shipment_count: number; weight_kg: number; emissions_kg: number }
+  >;
+  hotspots: Array<{
+    shipment_id: string;
+    origin: string;
+    destination: string;
+    transport_method: string;
+    emissions_kg: number;
+  }>;
+  warnings: string[];
+  factor_source: string;
+  factor_version: string;
+  factor_applicability: string;
+  assumptions: string[];
+};
+
+export type ShipmentData = {
+  artifact?: Artifact | null;
+  accepted_rows: number;
+  errors: Array<{
+    row_number: number | null;
+    field: string | null;
+    message: string;
+  }>;
+  warnings: string[];
+  rows: ShipmentRow[];
+  analysis: ShipmentAnalysis;
+};
+
+export type SupplierCard = {
+  supplier_id: string;
+  name: string;
+  region: string | null;
+  certifications: string[];
+  transport_modes: string[];
+  document_count: number;
+  missing_fields: string[];
+};
+
+export type ArtifactKind =
+  | "shipment_dataset"
+  | "evidence_document"
+  | "report_snapshot";
+
+export type Artifact = {
+  artifact_id: string;
+  workspace_id: string;
+  kind: ArtifactKind;
+  title: string;
+  status: "processing" | "ready" | "failed";
+  source_type:
+    | "local_upload"
+    | "generated"
+    | "google_drive"
+    | "legacy_migration";
+  source_reference: string | null;
+  media_type: string | null;
+  content_sha256: string | null;
+  version: number;
+  metadata: Record<string, unknown>;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type ModeBreakdown = {
+  shipment_count: number;
+  weight_kg: number;
+  emissions_kg: number;
+};
+
+export type ReportData = {
+  generated_at: number;
+  shipment_analysis: {
+    shipment_count: number;
+    total_weight_kg: number;
+    total_emissions_kg: number;
+    total_emissions_tonnes: number;
+    mode_breakdown: Record<string, ModeBreakdown>;
+  };
+  scenario: {
+    baseline_mode: string;
+    alternative_mode: string;
+    shipment_count: number;
+    baseline_total_kg: number;
+    alternative_total_kg: number;
+    delta_kg: number;
+    delta_percent: number | null;
+  } | null;
+  suppliers: Array<{
+    supplier_id: string;
+    name: string;
+    region: string | null;
+    document_count: number;
+  }>;
+  methodology: {
+    factor_source: string;
+    factor_version: string;
+    factor_applicability: string;
+    assumptions: string[];
+    warnings: string[];
+  };
+};
+
+type WorkspaceData = {
+  workspaceId: string | null;
+  demoData: DemoDataStatus | null;
+  demoStatus: LoadStatus;
+  demoError: string | null;
+  shipments: ShipmentData | null;
+  shipmentsStatus: LoadStatus;
+  shipmentsError: string | null;
+  suppliers: SupplierCard[];
+  suppliersStatus: LoadStatus;
+  suppliersError: string | null;
+  artifacts: Artifact[];
+  artifactsStatus: LoadStatus;
+  artifactsError: string | null;
+  reports: Record<string, ReportData>;
+  reportStatuses: Record<string, LoadStatus>;
+  reportErrors: Record<string, string | null>;
+};
+
+type WorkspaceDataActions = {
+  setWorkspace: (workspaceId: string) => void;
+  resetWorkspace: () => void;
+  ensureDemoData: (force?: boolean) => Promise<DemoDataStatus>;
+  loadDemoData: () => Promise<DemoDataStatus>;
+  unloadDemoData: () => Promise<DemoDataStatus>;
+  ensureShipments: (force?: boolean) => Promise<ShipmentData>;
+  uploadShipments: (file: File) => Promise<ShipmentData>;
+  ensureSuppliers: (force?: boolean) => Promise<SupplierCard[]>;
+  ensureArtifacts: (force?: boolean) => Promise<Artifact[]>;
+  ensureReport: (mode: string, force?: boolean) => Promise<ReportData>;
+  refreshAfterEvidenceMutation: () => Promise<void>;
+  refreshAfterReportSnapshot: () => Promise<void>;
+  renameArtifact: (artifactId: string, title: string) => Promise<Artifact>;
+  deleteArtifact: (artifact: Artifact) => Promise<void>;
+};
+
+type WorkspaceDataStore = WorkspaceData & WorkspaceDataActions;
+
+function emptyWorkspaceData(workspaceId: string | null = null): WorkspaceData {
+  return {
+    workspaceId,
+    demoData: null,
+    demoStatus: "idle",
+    demoError: null,
+    shipments: null,
+    shipmentsStatus: "idle",
+    shipmentsError: null,
+    suppliers: [],
+    suppliersStatus: "idle",
+    suppliersError: null,
+    artifacts: [],
+    artifactsStatus: "idle",
+    artifactsError: null,
+    reports: {},
+    reportStatuses: {},
+    reportErrors: {},
+  };
+}
+
+type RequestKey = "demo" | "shipments" | "suppliers" | "artifacts";
+
+const inFlight = new Map<string, Promise<unknown>>();
+let requestEpoch = 0;
+
+function requestKey(
+  workspaceId: string,
+  resource: RequestKey | `report:${string}`,
+) {
+  return `${workspaceId}:${resource}`;
+}
+
+function clearRequests() {
+  inFlight.clear();
+  requestEpoch += 1;
+}
+
+async function responseDetail(response: Response, fallback: string) {
+  const payload = (await response.json().catch(() => null)) as {
+    detail?: string;
+  } | null;
+  return payload?.detail ?? fallback;
+}
+
+function requireWorkspace(workspaceId: string | null): string {
+  if (!workspaceId) throw new Error("The workspace is not ready yet.");
+  return workspaceId;
+}
+
+export const useWorkspaceDataStore = create<WorkspaceDataStore>((set, get) => ({
+  ...emptyWorkspaceData(),
+
+  setWorkspace(workspaceId) {
+    if (get().workspaceId === workspaceId) return;
+    clearRequests();
+    set(emptyWorkspaceData(workspaceId));
+  },
+
+  resetWorkspace() {
+    clearRequests();
+    set(emptyWorkspaceData());
+  },
+
+  async ensureDemoData(force = false) {
+    const workspaceId = requireWorkspace(get().workspaceId);
+    if (!force && get().demoStatus === "ready" && get().demoData) {
+      return get().demoData as DemoDataStatus;
+    }
+    const key = requestKey(workspaceId, "demo");
+    const existing = inFlight.get(key) as Promise<DemoDataStatus> | undefined;
+    if (existing) return existing;
+
+    const epoch = requestEpoch;
+    set({ demoStatus: "loading", demoError: null });
+    const request = fetch(`${getBackendUrl()}/demo/data`, {
+      credentials: "include",
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            await responseDetail(
+              response,
+              "Workspace data status is unavailable.",
+            ),
+          );
+        }
+        return (await response.json()) as DemoDataStatus;
+      })
+      .then((payload) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set({ demoData: payload, demoStatus: "ready", demoError: null });
+        }
+        return payload;
+      })
+      .catch((error: unknown) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set({
+            demoStatus: "error",
+            demoError:
+              error instanceof Error
+                ? error.message
+                : "Workspace data status is unavailable.",
+          });
+        }
+        throw error;
+      })
+      .finally(() => {
+        if (inFlight.get(key) === request) inFlight.delete(key);
+      });
+    inFlight.set(key, request);
+    return request;
+  },
+
+  async loadDemoData() {
+    const workspaceId = requireWorkspace(get().workspaceId);
+    clearRequests();
+    const epoch = requestEpoch;
+    set({ demoStatus: "loading", demoError: null });
+    try {
+      const response = await fetch(`${getBackendUrl()}/demo/data`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!response.ok) {
+        throw new Error(
+          await responseDetail(response, "Demo data could not be loaded."),
+        );
+      }
+      const payload = (await response.json()) as DemoDataStatus;
+      if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+        set({
+          demoData: payload,
+          demoStatus: "ready",
+          demoError: null,
+          shipmentsStatus: "idle",
+          suppliersStatus: "idle",
+          artifactsStatus: "idle",
+          reports: {},
+          reportStatuses: {},
+          reportErrors: {},
+        });
+        await Promise.allSettled([
+          get().ensureShipments(true),
+          get().ensureSuppliers(true),
+          get().ensureArtifacts(true),
+        ]);
+      }
+      return payload;
+    } catch (error) {
+      if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+        set({
+          demoStatus: "error",
+          demoError:
+            error instanceof Error
+              ? error.message
+              : "Demo data could not be loaded.",
+        });
+      }
+      throw error;
+    }
+  },
+
+  async unloadDemoData() {
+    const workspaceId = requireWorkspace(get().workspaceId);
+    clearRequests();
+    const epoch = requestEpoch;
+    set({ demoStatus: "loading", demoError: null });
+    try {
+      const response = await fetch(`${getBackendUrl()}/demo/data`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!response.ok) {
+        throw new Error(
+          await responseDetail(response, "Demo data could not be removed."),
+        );
+      }
+      const payload = (await response.json()) as DemoDataStatus;
+      if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+        set({
+          demoData: payload,
+          demoStatus: "ready",
+          demoError: null,
+          shipments: null,
+          shipmentsStatus: "idle",
+          suppliersStatus: "idle",
+          artifactsStatus: "idle",
+          reports: {},
+          reportStatuses: {},
+          reportErrors: {},
+        });
+        await Promise.allSettled([
+          get().ensureShipments(true),
+          get().ensureSuppliers(true),
+          get().ensureArtifacts(true),
+        ]);
+      }
+      return payload;
+    } catch (error) {
+      if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+        set({
+          demoStatus: "error",
+          demoError:
+            error instanceof Error
+              ? error.message
+              : "Demo data could not be removed.",
+        });
+      }
+      throw error;
+    }
+  },
+
+  async ensureShipments(force = false) {
+    const workspaceId = requireWorkspace(get().workspaceId);
+    if (!force && get().shipmentsStatus === "ready" && get().shipments) {
+      return get().shipments as ShipmentData;
+    }
+    const key = requestKey(workspaceId, "shipments");
+    const existing = inFlight.get(key) as Promise<ShipmentData> | undefined;
+    if (existing) return existing;
+    const epoch = requestEpoch;
+    set({ shipmentsStatus: "loading", shipmentsError: null });
+    const request = fetch(`${getBackendUrl()}/shipments`, {
+      credentials: "include",
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            await responseDetail(
+              response,
+              "Shipment data could not be loaded.",
+            ),
+          );
+        }
+        return (await response.json()) as ShipmentData;
+      })
+      .then((payload) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set({
+            shipments: payload,
+            shipmentsStatus: "ready",
+            shipmentsError: null,
+          });
+        }
+        return payload;
+      })
+      .catch((error: unknown) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set({
+            shipmentsStatus: "error",
+            shipmentsError:
+              error instanceof Error
+                ? error.message
+                : "Shipment data could not be loaded.",
+          });
+        }
+        throw error;
+      })
+      .finally(() => {
+        if (inFlight.get(key) === request) inFlight.delete(key);
+      });
+    inFlight.set(key, request);
+    return request;
+  },
+
+  async uploadShipments(file) {
+    const workspaceId = requireWorkspace(get().workspaceId);
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await fetch(`${getBackendUrl()}/shipments/upload`, {
+      method: "POST",
+      body: formData,
+      credentials: "include",
+    });
+    if (!response.ok) {
+      throw new Error(
+        await responseDetail(response, "Shipment data could not be uploaded."),
+      );
+    }
+    const payload = (await response.json()) as ShipmentData;
+    if (get().workspaceId !== workspaceId) {
+      throw new Error("The active workspace changed during upload.");
+    }
+    set({ shipments: payload, shipmentsStatus: "ready", shipmentsError: null });
+    if (payload.accepted_rows > 0) {
+      clearRequests();
+      set({
+        artifactsStatus: "idle",
+        demoStatus: "idle",
+        reports: {},
+        reportStatuses: {},
+        reportErrors: {},
+      });
+      await Promise.allSettled([
+        get().ensureArtifacts(true),
+        get().ensureDemoData(true),
+      ]);
+    }
+    return payload;
+  },
+
+  async ensureSuppliers(force = false) {
+    const workspaceId = requireWorkspace(get().workspaceId);
+    if (!force && get().suppliersStatus === "ready") return get().suppliers;
+    const key = requestKey(workspaceId, "suppliers");
+    const existing = inFlight.get(key) as Promise<SupplierCard[]> | undefined;
+    if (existing) return existing;
+    const epoch = requestEpoch;
+    set({ suppliersStatus: "loading", suppliersError: null });
+    const request = fetch(`${getBackendUrl()}/suppliers`, {
+      credentials: "include",
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            await responseDetail(
+              response,
+              "Supplier evidence could not be loaded.",
+            ),
+          );
+        }
+        const payload = (await response.json()) as {
+          suppliers: SupplierCard[];
+        };
+        return payload.suppliers;
+      })
+      .then((payload) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set({
+            suppliers: payload,
+            suppliersStatus: "ready",
+            suppliersError: null,
+          });
+        }
+        return payload;
+      })
+      .catch((error: unknown) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set({
+            suppliersStatus: "error",
+            suppliersError:
+              error instanceof Error
+                ? error.message
+                : "Supplier evidence could not be loaded.",
+          });
+        }
+        throw error;
+      })
+      .finally(() => {
+        if (inFlight.get(key) === request) inFlight.delete(key);
+      });
+    inFlight.set(key, request);
+    return request;
+  },
+
+  async ensureArtifacts(force = false) {
+    const workspaceId = requireWorkspace(get().workspaceId);
+    if (!force && get().artifactsStatus === "ready") return get().artifacts;
+    const key = requestKey(workspaceId, "artifacts");
+    const existing = inFlight.get(key) as Promise<Artifact[]> | undefined;
+    if (existing) return existing;
+    const epoch = requestEpoch;
+    set({ artifactsStatus: "loading", artifactsError: null });
+    const request = fetch(`${getBackendUrl()}/artifacts`, {
+      credentials: "include",
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            await responseDetail(
+              response,
+              "Workspace artifacts could not be loaded.",
+            ),
+          );
+        }
+        const payload = (await response.json()) as { artifacts: Artifact[] };
+        return payload.artifacts;
+      })
+      .then((payload) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set({
+            artifacts: payload,
+            artifactsStatus: "ready",
+            artifactsError: null,
+          });
+        }
+        return payload;
+      })
+      .catch((error: unknown) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set({
+            artifactsStatus: "error",
+            artifactsError:
+              error instanceof Error
+                ? error.message
+                : "Workspace artifacts could not be loaded.",
+          });
+        }
+        throw error;
+      })
+      .finally(() => {
+        if (inFlight.get(key) === request) inFlight.delete(key);
+      });
+    inFlight.set(key, request);
+    return request;
+  },
+
+  async ensureReport(mode, force = false) {
+    const workspaceId = requireWorkspace(get().workspaceId);
+    if (
+      !force &&
+      get().reportStatuses[mode] === "ready" &&
+      get().reports[mode]
+    ) {
+      return get().reports[mode];
+    }
+    const key = requestKey(workspaceId, `report:${mode}`);
+    const existing = inFlight.get(key) as Promise<ReportData> | undefined;
+    if (existing) return existing;
+    const epoch = requestEpoch;
+    set((state) => ({
+      reportStatuses: { ...state.reportStatuses, [mode]: "loading" },
+      reportErrors: { ...state.reportErrors, [mode]: null },
+    }));
+    const query = mode ? `?alternative_mode=${encodeURIComponent(mode)}` : "";
+    const request = fetch(`${getBackendUrl()}/reports/preview${query}`, {
+      credentials: "include",
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            await responseDetail(
+              response,
+              "The report preview could not be loaded.",
+            ),
+          );
+        }
+        return (await response.json()) as ReportData;
+      })
+      .then((payload) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set((state) => ({
+            reports: { ...state.reports, [mode]: payload },
+            reportStatuses: { ...state.reportStatuses, [mode]: "ready" },
+            reportErrors: { ...state.reportErrors, [mode]: null },
+          }));
+        }
+        return payload;
+      })
+      .catch((error: unknown) => {
+        if (get().workspaceId === workspaceId && requestEpoch === epoch) {
+          set((state) => ({
+            reportStatuses: { ...state.reportStatuses, [mode]: "error" },
+            reportErrors: {
+              ...state.reportErrors,
+              [mode]:
+                error instanceof Error
+                  ? error.message
+                  : "The report preview could not be loaded.",
+            },
+          }));
+        }
+        throw error;
+      })
+      .finally(() => {
+        if (inFlight.get(key) === request) inFlight.delete(key);
+      });
+    inFlight.set(key, request);
+    return request;
+  },
+
+  async refreshAfterEvidenceMutation() {
+    clearRequests();
+    set({
+      suppliersStatus: "idle",
+      artifactsStatus: "idle",
+      demoStatus: "idle",
+      reports: {},
+      reportStatuses: {},
+      reportErrors: {},
+    });
+    await Promise.allSettled([
+      get().ensureSuppliers(true),
+      get().ensureArtifacts(true),
+      get().ensureDemoData(true),
+    ]);
+  },
+
+  async refreshAfterReportSnapshot() {
+    await get().ensureArtifacts(true);
+  },
+
+  async renameArtifact(artifactId, title) {
+    const response = await fetch(`${getBackendUrl()}/artifacts/${artifactId}`, {
+      method: "PATCH",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title }),
+    });
+    if (!response.ok) {
+      throw new Error(
+        await responseDetail(response, "Artifact could not be renamed."),
+      );
+    }
+    const updated = (await response.json()) as Artifact;
+    set((state) => ({
+      artifacts: state.artifacts.map((artifact) =>
+        artifact.artifact_id === updated.artifact_id ? updated : artifact,
+      ),
+    }));
+    return updated;
+  },
+
+  async deleteArtifact(artifact) {
+    const response = await fetch(
+      `${getBackendUrl()}/artifacts/${artifact.artifact_id}`,
+      { method: "DELETE", credentials: "include" },
+    );
+    if (!response.ok) {
+      throw new Error(
+        await responseDetail(response, "Artifact could not be deleted."),
+      );
+    }
+    clearRequests();
+    set((state) => ({
+      artifacts: state.artifacts.filter(
+        (item) => item.artifact_id !== artifact.artifact_id,
+      ),
+      artifactsStatus: "ready",
+      shipments: artifact.kind === "shipment_dataset" ? null : state.shipments,
+      shipmentsStatus:
+        artifact.kind === "shipment_dataset" ? "idle" : state.shipmentsStatus,
+      suppliersStatus:
+        artifact.kind === "evidence_document" ? "idle" : state.suppliersStatus,
+      demoStatus: "idle",
+      reports: {},
+      reportStatuses: {},
+      reportErrors: {},
+    }));
+    const refreshes: Promise<unknown>[] = [get().ensureDemoData(true)];
+    if (artifact.kind === "shipment_dataset") {
+      refreshes.push(get().ensureShipments(true));
+    }
+    if (artifact.kind === "evidence_document") {
+      refreshes.push(get().ensureSuppliers(true));
+    }
+    await Promise.allSettled(refreshes);
+  },
+}));

--- a/nzeroesg-client/e2e/demo.spec.ts
+++ b/nzeroesg-client/e2e/demo.spec.ts
@@ -45,6 +45,13 @@ async function openWorkspacePage(page: Page, label: string, path: string) {
   ).toHaveAttribute("aria-current", "page");
 }
 
+async function openShipmentImport(page: Page) {
+  await page.getByRole("button", { name: "Import shipments" }).click();
+  const dialog = page.getByRole("dialog", { name: "Import shipments" });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
 test("completes the five-minute demo workflow and exports a report", async ({
   page,
 }) => {
@@ -52,12 +59,15 @@ test("completes the five-minute demo workflow and exports a report", async ({
   await enterWorkspace(page);
   await openWorkspacePage(page, "Shipments", "shipments");
 
-  await page.getByLabel("Shipment file").setInputFiles({
+  const shipmentDialog = await openShipmentImport(page);
+  await shipmentDialog.getByLabel("Shipment file").setInputFiles({
     name: "shipments.csv",
     mimeType: "text/csv",
     buffer: Buffer.from(shipmentCsv),
   });
-  await page.getByRole("button", { name: "Upload and analyze" }).click();
+  await shipmentDialog
+    .getByRole("button", { name: "Upload and analyze" })
+    .click();
   await expect(page.getByText("Shipments", { exact: true }).last()).toBeVisible(
     {
       timeout: backendActionTimeout,
@@ -123,6 +133,12 @@ test("completes the five-minute demo workflow and exports a report", async ({
   ).toBeVisible();
   await expect(page.getByText("Coming soon", { exact: true })).toBeVisible();
 
+  let reportPreviewRequests = 0;
+  page.on("request", (request) => {
+    if (new URL(request.url()).pathname === "/reports/preview") {
+      reportPreviewRequests += 1;
+    }
+  });
   await openWorkspacePage(page, "Report", "report");
   await expect(page.getByText("Current baseline")).toBeVisible({
     timeout: backendActionTimeout,
@@ -147,6 +163,9 @@ test("completes the five-minute demo workflow and exports a report", async ({
   await expect(
     page.getByText("Report snapshot", { exact: true }),
   ).toBeVisible();
+  await openWorkspacePage(page, "Report", "report");
+  await expect(page.getByText("Current baseline")).toBeVisible();
+  expect(reportPreviewRequests).toBe(1);
   const workspaceMenu = page.getByRole("button", {
     name: "Open workspace menu",
   });
@@ -214,17 +233,33 @@ test("loads the fictional demo dataset from the agent or integrations", async ({
   await expect(
     page.getByText("Coastal Biofuels", { exact: true }),
   ).toBeVisible();
+
+  await openWorkspacePage(page, "Integrations", "integrations");
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Unload demo data" }).click();
+  await expect(
+    page.getByRole("button", { name: "Load demo data" }),
+  ).toBeVisible({ timeout: backendActionTimeout });
+  await openWorkspacePage(page, "Artifacts", "artifacts");
+  await expect(
+    page.getByText(
+      "No active artifacts yet. Load demo data or upload shipment and supplier sources to begin.",
+    ),
+  ).toBeVisible({ timeout: backendActionTimeout });
 });
 
 test("keeps two demo workspaces isolated", async ({ page, browser }) => {
   await enterWorkspace(page);
   await openWorkspacePage(page, "Shipments", "shipments");
-  await page.getByLabel("Shipment file").setInputFiles({
+  const shipmentDialog = await openShipmentImport(page);
+  await shipmentDialog.getByLabel("Shipment file").setInputFiles({
     name: "shipments.csv",
     mimeType: "text/csv",
     buffer: Buffer.from(shipmentCsv),
   });
-  await page.getByRole("button", { name: "Upload and analyze" }).click();
+  await shipmentDialog
+    .getByRole("button", { name: "Upload and analyze" })
+    .click();
   await expect(page.getByText("Shipments", { exact: true }).last()).toBeVisible(
     {
       timeout: backendActionTimeout,
@@ -258,12 +293,15 @@ test("soft-deletes a shipment artifact and removes its active analysis", async (
 }) => {
   await enterWorkspace(page);
   await openWorkspacePage(page, "Shipments", "shipments");
-  await page.getByLabel("Shipment file").setInputFiles({
+  const shipmentDialog = await openShipmentImport(page);
+  await shipmentDialog.getByLabel("Shipment file").setInputFiles({
     name: "shipments.csv",
     mimeType: "text/csv",
     buffer: Buffer.from(shipmentCsv),
   });
-  await page.getByRole("button", { name: "Upload and analyze" }).click();
+  await shipmentDialog
+    .getByRole("button", { name: "Upload and analyze" })
+    .click();
   await expect(page.getByText("Shipments", { exact: true }).last()).toBeVisible(
     {
       timeout: backendActionTimeout,
@@ -292,12 +330,15 @@ test("explains when a supplier CSV is selected as shipment data", async ({
 }) => {
   await enterWorkspace(page);
   await openWorkspacePage(page, "Shipments", "shipments");
-  await page.getByLabel("Shipment file").setInputFiles({
+  const shipmentDialog = await openShipmentImport(page);
+  await shipmentDialog.getByLabel("Shipment file").setInputFiles({
     name: "carbonsage-suppliers.csv",
     mimeType: "text/csv",
     buffer: Buffer.from(emptySupplierCsv),
   });
-  await page.getByRole("button", { name: "Upload and analyze" }).click();
+  await shipmentDialog
+    .getByRole("button", { name: "Upload and analyze" })
+    .click();
 
   await expect(page.getByText("We couldn’t import this file")).toBeVisible({
     timeout: backendActionTimeout,
@@ -316,10 +357,11 @@ test("keeps the deterministic workspace usable when the agent is disabled", asyn
   await expect(page.getByLabel("Message CarbonSage")).toBeDisabled();
 
   await openWorkspacePage(page, "Shipments", "shipments");
-  await expect(page.getByLabel("Shipment file")).toBeEnabled();
+  const shipmentDialog = await openShipmentImport(page);
+  await expect(shipmentDialog.getByLabel("Shipment file")).toBeEnabled();
   await expect(
-    page.getByRole("button", { name: "Upload and analyze" }),
-  ).toBeEnabled();
+    shipmentDialog.getByRole("button", { name: "Upload and analyze" }),
+  ).toBeDisabled();
 });
 
 test("restores the latest workspace conversation before enabling input", async ({
@@ -338,6 +380,8 @@ test("restores the latest workspace conversation before enabling input", async (
     expires_at: new Date(Date.now() + 3_600_000).toISOString(),
   };
   let createRequested = false;
+  let conversationListRequests = 0;
+  let conversationDetailRequests = 0;
 
   await page.route("**/agent/health", (route) =>
     route.fulfill({
@@ -357,10 +401,12 @@ test("restores the latest workspace conversation before enabling input", async (
         json: { detail: "Unexpected create" },
       });
     }
+    conversationListRequests += 1;
     return route.fulfill({ json: { conversations: [conversation] } });
   });
-  await page.route("**/agent/conversations/*", (route) =>
-    route.fulfill({
+  await page.route("**/agent/conversations/*", (route) => {
+    conversationDetailRequests += 1;
+    return route.fulfill({
       json: {
         conversation,
         messages: [
@@ -395,8 +441,8 @@ test("restores the latest workspace conversation before enabling input", async (
         ],
         tool_events: [],
       },
-    }),
-  );
+    });
+  });
 
   await enterWorkspace(page);
   await openWorkspacePage(page, "Ask CarbonSage", "agent");
@@ -409,6 +455,16 @@ test("restores the latest workspace conversation before enabling input", async (
   ).toBeVisible();
   await expect(dialog.getByLabel("Message CarbonSage")).toBeEnabled();
   expect(createRequested).toBe(false);
+
+  await openWorkspacePage(page, "Shipments", "shipments");
+  await openWorkspacePage(page, "Ask CarbonSage", "agent");
+  await expect(
+    page
+      .getByRole("region", { name: "CarbonSage" })
+      .getByText("The previous decision is restored."),
+  ).toBeVisible();
+  expect(conversationListRequests).toBe(1);
+  expect(conversationDetailRequests).toBe(1);
 });
 
 test("creates, switches, and closes workspace conversations", async ({
@@ -786,11 +842,12 @@ test("supports keyboard entry and a narrow viewport", async ({ page }) => {
   await expect(
     page.getByRole("navigation", { name: "Workspace navigation" }),
   ).toBeVisible();
-  const shipmentInput = page.getByLabel("Shipment file");
+  const shipmentDialog = await openShipmentImport(page);
+  const shipmentInput = shipmentDialog.getByLabel("Shipment file");
   await shipmentInput.focus();
   await expect(shipmentInput).toBeFocused();
   await page.keyboard.press("Tab");
   await expect(
-    page.getByRole("button", { name: "Upload and analyze" }),
+    shipmentDialog.getByRole("link", { name: "Download XLSX template" }),
   ).toBeFocused();
 });

--- a/nzeroesg-client/eslint.config.mjs
+++ b/nzeroesg-client/eslint.config.mjs
@@ -3,7 +3,12 @@ import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 
 const config = [
   {
-    ignores: [".next/**", "node_modules/**", "next-env.d.ts"],
+    ignores: [
+      ".next/**",
+      ".next-playwright/**",
+      "node_modules/**",
+      "next-env.d.ts",
+    ],
   },
   ...nextCoreWebVitals,
   ...nextTypescript,

--- a/nzeroesg-client/next.config.ts
+++ b/nzeroesg-client/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  distDir: process.env.NEXT_DIST_DIR ?? ".next",
   output: "standalone",
   outputFileTracingRoot: process.cwd(),
 };

--- a/nzeroesg-client/package-lock.json
+++ b/nzeroesg-client/package-lock.json
@@ -18,7 +18,8 @@
         "next": "16.3.0",
         "postcss": "8.5.25",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "zustand": "5.0.14"
       },
       "devDependencies": {
         "@playwright/test": "1.62.1",
@@ -2209,7 +2210,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3330,7 +3331,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7442,6 +7443,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/nzeroesg-client/package.json
+++ b/nzeroesg-client/package.json
@@ -23,7 +23,8 @@
     "next": "16.3.0",
     "postcss": "8.5.25",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "zustand": "5.0.14"
   },
   "devDependencies": {
     "@playwright/test": "1.62.1",

--- a/nzeroesg-client/playwright.config.ts
+++ b/nzeroesg-client/playwright.config.ts
@@ -8,6 +8,7 @@ const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? localBaseURL;
 const useLocalServers = !process.env.PLAYWRIGHT_BASE_URL;
 const python = process.env.E2E_PYTHON ?? "../.venv/bin/python";
 const databaseUrl = process.env.E2E_DATABASE_URL ?? "";
+const testDistDir = process.env.PLAYWRIGHT_DIST_DIR ?? ".next-playwright";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -30,7 +31,7 @@ export default defineConfig({
           timeout: 120_000,
         },
         {
-          command: `NEXT_PUBLIC_BACKEND_URL=${localApiURL} npm run dev -- --hostname 127.0.0.1 --port ${frontendPort}`,
+          command: `NEXT_DIST_DIR=${testDistDir} NEXT_PUBLIC_BACKEND_URL=${localApiURL} npm run dev -- --hostname 127.0.0.1 --port ${frontendPort}`,
           url: `${localBaseURL}/login`,
           reuseExistingServer: !process.env.CI,
           timeout: 120_000,

--- a/nzeroesg-client/tsconfig.json
+++ b/nzeroesg-client/tsconfig.json
@@ -29,7 +29,9 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     "app/components/ParticlesContainer.tsx",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-playwright/types/**/*.ts",
+    ".next-playwright/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,8 @@ available independently.
   user uploads. The seed includes 24 supplier profiles, six mixed-mode
   shipments, and three cited disclosures. Demo sources, retained uploads,
   normalized shipments, and the supplier catalog are downloadable from the
-  workspace.
+  workspace, and the seeded records can be unloaded without deleting user
+  uploads.
 - Explicit lexical, pgvector semantic, and deterministic hybrid retrieval
   modes with workspace filtering, versioned embedding metadata, and a safe
   lexical fallback when no embedding provider is configured.
@@ -101,7 +102,9 @@ available independently.
   soft-deletion, and cross-workspace isolation.
 - An agent-first routed control plane with persistent navigation and standalone
   agent, integration, overview, artifact, shipment, supplier, scenario, and
-  report pages. Every section can be linked to or refreshed directly.
+  report pages. Workspace data is request-deduplicated and cached across route
+  changes, while mutations invalidate only affected views. Every section can be
+  linked to or refreshed directly.
 - A dedicated decision-agent testing page using the same workspace-scoped
   conversation API and structured renderer as the workspace launcher. Users
   can create, switch, and close conversations; inspect source coverage,


### PR DESCRIPTION
## What changed

- added a workspace-scoped Zustand cache for demo status, shipments, suppliers, artifacts, reports, and the shared agent lifecycle
- deduplicated in-flight reads and invalidated only dependent records after uploads, artifact changes, report snapshots, and demo-data mutations
- added safe server/client demo-data unload that preserves user-uploaded artifacts and normalized records
- moved shipment import into an accessible drag-and-drop modal beside Calculate freight
- removed the integrations status spinner during initial background resolution
- isolated Playwright's Next.js output so browser tests do not interfere with an existing development server

## Why

Route changes were repeating expensive API work and replacing usable content with long loading states. Demo data also had no reversible lifecycle, and the permanent shipment import form consumed core workspace space.

## Impact

Workspace pages now reuse current data across navigation, report and agent state remain mounted, demo simulation records can be removed independently of user uploads, and shipment import is an intentional modal flow.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:e2e` — 10 passed
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pytest -q` — full API suite passed with 4 expected skips
- `python3.12 scripts/check_secrets.py`
- `git diff --check`
