### PR TITLE
Deploy strict typed agent planning hotfix

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -214,16 +214,18 @@ CI must remain credential-free and run:
 The browser suite is a local/CI gate; it does not substitute for the public
 deployment smoke check.
 
-Public verification snapshot from August 8, 2026:
+Public verification snapshot from August 19, 2026:
 
-- `https://n-zero-esg-scope3.vercel.app/` serves the rebuilt client from
-  `main`, and `/login` returns `200`.
+- `https://www.carbonsage.ca/` serves the Vercel client; `carbonsage.ca`
+  redirects to that canonical origin. `carbonsage.org` redirects to the same
+  client while its DNS rollout is completed.
 - `https://nzeroesg-api.onrender.com/health` serves the `carbonsage-api`
   FastAPI service with Neon-backed production persistence and reports semantic
   search enabled.
-- The exact Vercel-origin CORS preflight passes.
-- The assistant health route is reachable and the disabled assistant fails
-  closed with `503` rather than affecting the deterministic workflow.
+- The assistant and custom-domain CORS deployment gates are pending a Render
+  environment update and restart. Until then, `/health` reports
+  `assistant_enabled: false`, `/agent/health` reports `available: false`, and
+  preflights from the CarbonSage domains are rejected.
 - The public Playwright journey passes shipment ingestion, cited evidence,
   scenarios, report export, workspace isolation, keyboard entry, and narrow
   viewport checks.

--- a/nzeroesg-api/agent/evidence_support.py
+++ b/nzeroesg-api/agent/evidence_support.py
@@ -30,6 +30,8 @@ class LlmEvidenceSupportAssessor:
         self._assessor = load_llm().with_structured_output(
             EvidenceSupportAssessment,
             include_raw=True,
+            method="json_schema",
+            strict=True,
         )
         self._policy = load_agent_policy()
         self.last_usage: dict[str, int] = {}

--- a/nzeroesg-api/agent/llm.py
+++ b/nzeroesg-api/agent/llm.py
@@ -26,6 +26,18 @@ def load_llm():
             api_key=settings.openrouter_api_key,
             base_url="https://openrouter.ai/api/v1",
             max_tokens=1_000,
+            timeout=30,
+            max_retries=2,
+            default_headers={
+                "HTTP-Referer": "https://www.carbonsage.ca",
+                "X-Title": "CarbonSage",
+            },
+            extra_body={
+                "provider": {
+                    "require_parameters": True,
+                    "data_collection": "deny",
+                }
+            },
         )
 
     raise RuntimeError("LLM_PROVIDER must be 'openai' or 'openrouter'.")

--- a/nzeroesg-api/agent/planner.py
+++ b/nzeroesg-api/agent/planner.py
@@ -29,7 +29,11 @@ class LlmAgentPlanner:
     """Uses a model only for tool selection; application code composes results."""
 
     def __init__(self) -> None:
-        self._planner = load_llm().with_structured_output(AgentPlan)
+        self._planner = load_llm().with_structured_output(
+            AgentPlan,
+            method="json_schema",
+            strict=True,
+        )
         self._policy = load_agent_policy()
 
     async def plan(

--- a/nzeroesg-api/api/agent.py
+++ b/nzeroesg-api/api/agent.py
@@ -141,7 +141,14 @@ def _runtime_exception(exc: Exception) -> HTTPException:
 
 
 @agent_router.get("/health")
-async def agent_health() -> dict[str, str | bool]:
+async def agent_health() -> dict[str, str | bool | None]:
+    configured_model = (
+        settings.openai_model
+        if settings.llm_provider == "openai"
+        else settings.openrouter_model
+        if settings.llm_provider == "openrouter"
+        else None
+    )
     return {
         "status": "ok",
         "available": (
@@ -150,6 +157,8 @@ async def agent_health() -> dict[str, str | bool]:
         ),
         "policy_version": AGENT_POLICY_VERSION,
         "response_schema_version": AGENT_RESPONSE_SCHEMA_VERSION,
+        "provider": settings.llm_provider or None,
+        "model": configured_model,
     }
 
 

--- a/nzeroesg-api/config.py
+++ b/nzeroesg-api/config.py
@@ -18,6 +18,15 @@ def _as_csv(value: str | None, *, default: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(item.strip() for item in value.split(",") if item.strip())
 
 
+def _optional_value(value: str | None) -> str | None:
+    """Normalize externally managed values without accepting whitespace-only input."""
+
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
 def _demo_session_secret() -> str:
     configured = os.getenv("DEMO_SESSION_SECRET")
     if configured:
@@ -33,19 +42,19 @@ class Settings:
     assistant_enabled: bool = _as_bool(os.getenv("ASSISTANT_ENABLED"))
     demo_session_secret: str = _demo_session_secret()
     demo_workspace_ttl_hours: int = int(os.getenv("DEMO_WORKSPACE_TTL_HOURS", "24"))
-    database_url: str | None = os.getenv("DATABASE_URL") or None
+    database_url: str | None = _optional_value(os.getenv("DATABASE_URL"))
     session_cookie_secure: bool = os.getenv("APP_ENV", "development") == "production"
     session_cookie_samesite: str = "none" if session_cookie_secure else "lax"
     llm_provider: str = os.getenv("LLM_PROVIDER", "").strip().lower()
-    openai_api_key: str | None = os.getenv("OPENAI_API_KEY")
-    openai_model: str | None = os.getenv("OPENAI_MODEL")
-    openrouter_api_key: str | None = os.getenv("OPENROUTER_API_KEY")
-    openrouter_model: str | None = os.getenv("OPENROUTER_MODEL")
+    openai_api_key: str | None = _optional_value(os.getenv("OPENAI_API_KEY"))
+    openai_model: str | None = _optional_value(os.getenv("OPENAI_MODEL"))
+    openrouter_api_key: str | None = _optional_value(os.getenv("OPENROUTER_API_KEY"))
+    openrouter_model: str | None = _optional_value(os.getenv("OPENROUTER_MODEL"))
     embedding_provider: str = os.getenv("EMBEDDING_PROVIDER", "").strip().lower()
-    embedding_model: str | None = os.getenv("EMBEDDING_MODEL") or None
+    embedding_model: str | None = _optional_value(os.getenv("EMBEDDING_MODEL"))
     embedding_dimensions: int = int(os.getenv("EMBEDDING_DIMENSIONS", "1536"))
     artifact_storage_enabled: bool = _as_bool(os.getenv("ARTIFACT_STORAGE_ENABLED"))
-    aws_s3_bucket: str | None = os.getenv("AWS_S3_BUCKET") or None
+    aws_s3_bucket: str | None = _optional_value(os.getenv("AWS_S3_BUCKET"))
     aws_s3_region: str = os.getenv("AWS_S3_REGION", "ca-central-1")
     artifact_storage_retention_hours: int = int(os.getenv("ARTIFACT_STORAGE_RETENTION_HOURS", "24"))
     artifact_storage_max_active_bytes: int = int(

--- a/nzeroesg-api/domain/agent/tools.py
+++ b/nzeroesg-api/domain/agent/tools.py
@@ -65,6 +65,17 @@ class BuildDecisionReportInput(StrictModel):
     alternative_transport_method: TransportMode | None = None
 
 
+ToolArguments = (
+    ListWorkspaceArtifactsInput
+    | SearchSupplierEvidenceInput
+    | GetCitationContextInput
+    | CalculateFreightEmissionsInput
+    | CompareTransportScenariosInput
+    | SummarizeDataQualityInput
+    | BuildDecisionReportInput
+)
+
+
 class ArtifactToolItem(StrictModel):
     artifact_id: str
     title: str
@@ -172,7 +183,7 @@ class BuildDecisionReportOutput(StrictModel):
 class PlannedToolCall(StrictModel):
     call_id: str = Field(pattern=r"^[a-zA-Z0-9_-]{1,80}$")
     tool_name: AgentToolName
-    arguments: dict[str, object]
+    arguments: ToolArguments
 
 
 class AgentPlan(StrictModel):

--- a/nzeroesg-api/services/agent_tools.py
+++ b/nzeroesg-api/services/agent_tools.py
@@ -101,7 +101,7 @@ class AgentToolRegistry:
         started_at = perf_counter()
         input_model = TOOL_INPUT_MODELS[call.tool_name]
         try:
-            validated = input_model.model_validate(call.arguments)
+            validated = input_model.model_validate(call.arguments.model_dump())
         except ValidationError:
             return ToolExecution(
                 call_id=call.call_id,

--- a/nzeroesg-api/tests/test_agent_runtime.py
+++ b/nzeroesg-api/tests/test_agent_runtime.py
@@ -59,6 +59,16 @@ class FixturePlanner:
         return self.result
 
 
+def _contains_open_object_schema(value: object) -> bool:
+    if isinstance(value, dict):
+        if value.get("additionalProperties") is True:
+            return True
+        return any(_contains_open_object_schema(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_open_object_schema(item) for item in value)
+    return False
+
+
 class FixtureEvidenceAssessor:
     def __init__(self, supported: bool) -> None:
         self.supported = supported
@@ -95,6 +105,14 @@ async def related_evidence_search(workspace_id, query, requested_mode):
         None,
         False,
     )
+
+
+def test_agent_plan_schema_closes_every_tool_argument_object():
+    schema = AgentPlan.model_json_schema()
+
+    assert not _contains_open_object_schema(schema)
+    argument_schema = schema["$defs"]["PlannedToolCall"]["properties"]["arguments"]
+    assert len(argument_schema["anyOf"]) == 7
 
 
 def principal_for(workspace_id: str = "demo-agent") -> WorkspacePrincipal:

--- a/nzeroesg-api/tests/test_api.py
+++ b/nzeroesg-api/tests/test_api.py
@@ -133,6 +133,8 @@ def test_typed_agent_health_exposes_versioned_local_contracts():
         "available": False,
         "policy_version": "1.0",
         "response_schema_version": "1.0",
+        "provider": None,
+        "model": None,
     }
 
 

--- a/nzeroesg-api/tests/test_workspace_sessions.py
+++ b/nzeroesg-api/tests/test_workspace_sessions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from config import _demo_session_secret
+from config import _demo_session_secret, _optional_value
 from domain.workspaces.sessions import SessionError, SessionSigner
 
 
@@ -47,3 +47,10 @@ def test_production_does_not_fall_back_to_a_development_secret(monkeypatch):
     monkeypatch.delenv("DEMO_SESSION_SECRET", raising=False)
 
     assert _demo_session_secret() == ""
+
+
+def test_external_values_are_trimmed_and_empty_values_are_rejected():
+    assert _optional_value("  openai/gpt-4.1-mini  ") == "openai/gpt-4.1-mini"
+    assert _optional_value("  secret-value\t") == "secret-value"
+    assert _optional_value("   ") is None
+    assert _optional_value(None) is None

--- a/readme.md
+++ b/readme.md
@@ -32,9 +32,9 @@ choosing typed tools, and explaining validated results.
 
 ## Try the current demo
 
-The trusted deterministic baseline is live at:
+The current CarbonSage demo is live at:
 
-<https://n-zero-esg-scope3.vercel.app/>
+<https://www.carbonsage.ca/>
 
 The intended path is short:
 
@@ -228,7 +228,7 @@ configured. It can be enabled in `nzeroesg-api/.env`:
 ASSISTANT_ENABLED=true
 LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=...
-OPENROUTER_MODEL=openai/gpt-3.5-turbo-16k
+OPENROUTER_MODEL=openai/gpt-4.1-mini
 ```
 
 OpenAI is also supported directly. No provider credential is required for
@@ -243,8 +243,9 @@ EMBEDDING_DIMENSIONS=1536
 ```
 
 For OpenRouter, use `openrouter` as the provider and its provider-qualified
-embedding model identifier. Lexical retrieval remains available without these
-settings.
+embedding model identifier. Semantic retrieval is enabled by a valid embedding
+provider configuration; no separate `SEMANTIC_SEARCH_ENABLED` flag is required.
+Lexical retrieval remains available without these settings.
 
 ## Quality checks
 

--- a/render.yaml
+++ b/render.yaml
@@ -21,9 +21,9 @@ services:
       - key: LLM_PROVIDER
         value: openrouter
       - key: OPENROUTER_MODEL
-        value: openai/gpt-3.5-turbo-16k
+        value: openai/gpt-4.1-mini
       - key: CORS_ORIGINS
-        value: https://n-zero-esg-scope3.vercel.app,http://localhost:3000,http://127.0.0.1:3000
+        value: https://www.carbonsage.ca,https://carbonsage.ca,https://www.carbonsage.org,https://carbonsage.org,https://n-zero-esg-scope3.vercel.app,http://localhost:3000,http://127.0.0.1:3000
       - key: DEMO_SESSION_SECRET
         generateValue: true
       - key: DATABASE_URL


### PR DESCRIPTION
## Production gate

Promotes the reviewed, fully green typed-agent hotfix from dev to main.

## Included

- closed schemas for all approved planner tool arguments
- strict OpenRouter structured-output routing
- normalized provider configuration
- non-secret provider/model health diagnostics
- current CarbonSage origins and GPT-4.1 Mini deployment defaults

## Validation

PR #27 passed backend, frontend, repository, E2E, and Vercel checks. Production already passes canonical-origin CORS, authenticated sessions, demo-data loading, and hybrid pgvector retrieval. After this merge and Render deployment, the final gate is three real typed-tool requests.